### PR TITLE
SMA Sunny Home Manager 2.0 Fixes

### DIFF
--- a/src/main/java/com/deigmueller/uni_meter/input/device/sma/energy_meter/EnergyMeter.java
+++ b/src/main/java/com/deigmueller/uni_meter/input/device/sma/energy_meter/EnergyMeter.java
@@ -115,6 +115,7 @@ public class EnergyMeter extends InputDevice {
           logger.info("auto detected {} with serial number {}", device, packet.serialNumber());
           susyId = packet.susyId();
           serialNumber = packet.serialNumber();
+          return true;
         }
       }
     }

--- a/src/main/java/com/deigmueller/uni_meter/input/device/sma/energy_meter/Telegram.java
+++ b/src/main/java/com/deigmueller/uni_meter/input/device/sma/energy_meter/Telegram.java
@@ -82,10 +82,6 @@ public record Telegram(
   }
   
   public @Nullable Double getActivePowerPhase3Plus() {
-    Double result = getValue(ObisChannel.CHANNEL_61_8_0);
-    if (result != null) {
-      return result;
-    }
     return getValue(ObisChannel.CHANNEL_61_4_0);
   }
 


### PR DESCRIPTION
Such a great project, thanks a lot!

Minor fixes to get Sunny Home Manager 2.0 up and running. One missing return statement and a wrong OBIS number used for active power on phase 3.

I haven't tested to add this as a Shelly device, but the correct output on the OutputDevice was verified with some more debug output and checked against the values in my ioBroker instance, see screenshot.

I ran the app on my MacBook directly by simply modifying the reference.conf to use "en0" for wifi and removed the VZLogger input from the conf as well, no other changes made.

<img width="1352" alt="uni-meter shm20" src="https://github.com/user-attachments/assets/e66414fc-3f5a-4d9a-aa90-11636693f93e">
