### PR TITLE
Fixes hardcoded JAR version in uni-meter.sh

### DIFF
--- a/assembly.xml
+++ b/assembly.xml
@@ -13,19 +13,19 @@
     <fileSets>
         <fileSet>
             <lineEnding>unix</lineEnding>
-            <directory>src${file.separator}main${file.separator}resources${file.separator}config</directory>
+            <directory>${project.build.outputDirectory}${file.separator}config</directory>
             <outputDirectory>${file.separator}config</outputDirectory>
         </fileSet>
         <fileSet>
             <lineEnding>unix</lineEnding>
-            <directory>src${file.separator}main${file.separator}resources${file.separator}bin</directory>
+            <directory>${project.build.outputDirectory}${file.separator}bin</directory>
             <outputDirectory>${file.separator}bin</outputDirectory>
         </fileSet>
     </fileSets>
 
     <files>
         <file>
-            <source>src${file.separator}main${file.separator}resources${file.separator}bin${file.separator}uni-meter.sh</source>
+            <source>${project.build.outputDirectory}${file.separator}bin${file.separator}uni-meter.sh</source>
             <outputDirectory>${file.separator}bin</outputDirectory>
             <destName>uni-meter.sh</destName>
             <lineEnding>unix</lineEnding>

--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,16 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
+                <directory>src/main/resources-filtered</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
+
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/resources-filtered/bin/uni-meter.sh
+++ b/src/main/resources-filtered/bin/uni-meter.sh
@@ -3,4 +3,4 @@
 /usr/bin/java \
  -Dlogback.configurationFile=/opt/uni-meter/config/logback.xml \
  -Dconfig.file=/etc/uni-meter.conf \
- -jar /opt/uni-meter/lib/uni-meter-0.9.0-SNAPSHOT.jar 
+ -jar /opt/uni-meter/lib/uni-meter-${project.version}.jar


### PR DESCRIPTION
Fixes the hardcoded version 0.9.0-SNAPSHOT in uni-meter.sh start script by applying resource filtering.

BTW it is fine to replace `${file.separator}` with simply a forward slash `/`, this works on all operating systems (including Windows)