### PR TITLE
refactor: Dockerfile to reduce size and build it within the docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+Dockerfile
+README.md
+samples/
+target/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,25 @@
+FROM debian:bookworm-slim AS builder
+WORKDIR /src
+RUN apt-get update && apt-get install -y openjdk-17-jdk-headless maven
+COPY . /src
+RUN mvn install
+
+# ---
+
 FROM debian:bookworm-slim
+# Install Java 17 & avahi & disable d-bus
+RUN apt-get update && \
+    apt-get install -y openjdk-17-jre-headless && \
+    apt-get install -y avahi-daemon && \
+    sed -i 's/.*enable-dbus=.*/enable-dbus=no/' /etc/avahi/avahi-daemon.conf && \
+    sed -i 's/#allow-interfaces=eth0/allow-interfaces=eth0/' /etc/avahi/avahi-daemon.conf && \
+    apt-get -qq clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/*
 
-ARG version="1.0.4-SNAPSHOT"
-
-ENV VERSION=$version
-
-RUN apt-get update 
-
-#
-# Install Java 17
-#
-RUN apt install -y openjdk-17-jre
-
-#
-# Install avahi
-#
-RUN apt-get install -y avahi-daemon
-
-# disable d-bus
-RUN sed -i 's/.*enable-dbus=.*/enable-dbus=no/' /etc/avahi/avahi-daemon.conf
-RUN sed -i 's/#allow-interfaces=eth0/allow-interfaces=eth0/' /etc/avahi/avahi-daemon.conf
-
-#
 # Install uni-meter
-#
-ADD target/uni-meter-${VERSION}.tgz /opt
-RUN ln -s /opt/uni-meter-${VERSION} /opt/uni-meter
-RUN cp /opt/uni-meter/config/uni-meter.conf /etc
+RUN --mount=type=bind,target=/helper,source=/src,from=builder \
+    mkdir -p /opt/uni-meter && \
+    tar --strip-components 1 -xzf /helper/target/uni-meter-*.tgz -C /opt/uni-meter && \
+    cp /opt/uni-meter/config/uni-meter.conf /etc
 
 ENTRYPOINT ["/opt/uni-meter/bin/uni-meter-and-avahi.sh"]


### PR DESCRIPTION
# what 
* make a clean build of uni-meter also within docker
* reduce size of image by using headless jre versions and cleaning up a bit (630MB->382MB)
* also less layers, for better cleanup
* ignore some stuff irrelevant to the build in docker context (like target

# tests
```sh
❯ docker run --rm -it d7f21d16bd39                                                                                                                                     12:26:03
25-04-25 10:26:17.464 INFO  uni-meter                - ###########################################################################
25-04-25 10:26:17.466 INFO  uni-meter                - # Universal electric meter converter 1.1.7-SNAPSHOT (2025-04-25 10:14:18) #
25-04-25 10:26:17.466 INFO  uni-meter                - ###########################################################################
25-04-25 10:26:17.466 INFO  uni-meter                - initializing actor system
25-04-25 10:26:17.914 INFO  org.apache.pekko.event.slf4j.Slf4jLogger - Slf4jLogger started
25-04-25 10:26:18.149 INFO  uni-meter.controller     - creating ShellyPro3EM output device
25-04-25 10:26:18.164 INFO  uni-meter.controller     - creating VZLogger input device
25-04-25 10:26:18.490 INFO  uni-meter.mdns.avahi     - successfully registered mdns service shellypro3em-0242c0a8d702
25-04-25 10:26:18.935 INFO  uni-meter.http.port-80   - HTTP server is listening on /[0:0:0:0:0:0:0:0]:80

```