### PR TITLE
Mention clientContext for ShellyPro3EM

### DIFF
--- a/doc/output/ShellyPro3EM.md
+++ b/doc/output/ShellyPro3EM.md
@@ -107,3 +107,36 @@ uni-meter {
   #...
 }
 ```
+
+## Configuring client specific behaviour
+
+Unimeter can pretend to be different devices for each connecting client. For each client, specified via
+address, the MAC adress and the power factor can be configured.
+By this, the power from the input device can be unequal distributed over multiple batteries.
+
+```hocon
+uni-meter {
+  #...
+  output-devices {
+    shelly-pro3em {
+      #...
+      client-contexts = [{
+        # See correct data from local machine
+        address = "127.0.0.1"
+        mac = "abcdef0123456"
+        power-factor = 1.0      
+      },{
+        # Small batterie
+        address = "192.168.178.30"
+        mac = "bcdef01234567"
+        power-factor = 0.3     
+      },{
+        # Big batterie
+        address = "192.168.178.70"
+        mac = "cdef012345678"
+        power-factor = 0.7     
+      }]
+    }
+  }
+}
+```


### PR DESCRIPTION
In the clientcontexts configuration node, specific behaviour of the connected client
- mac address
- power-factor can be given.

See https://github.com/sdeigm/uni-meter/issues/193 and [ShellyClientContext](https://github.com/sdeigm/uni-meter/blob/main/src/main/java/com/deigmueller/uni_meter/output/device/shelly/Shelly.java#L371)