### PR TITLE
Feature request: add a ramp down to no_discharge

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,12 +120,12 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>1.5.12</version>
+            <version>1.5.13</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.17.0</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>com.digitalpetri.modbus</groupId>

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -28,12 +28,25 @@ uni-meter {
   }
   
   output-devices {
-    shelly-pro3em {
-      type = "ShellyPro3EM"
-      
+    common {
       forget-interval = 1m
       default-voltage = 230
       default-frequency = 50
+
+      power-offset-total = 0
+      power-offset-l1 = 0
+      power-offset-l2 = 0
+      power-offset-l3 = 0
+
+      default-client-power-factor = 1.0
+      client-contexts = []
+
+      usage-constraint-init-duration = 60s
+    }
+    
+    shelly-pro3em {
+      type = "ShellyPro3EM"
+      
       port = 80
       interface = "0.0.0.0"
       udp-port = -1
@@ -41,14 +54,6 @@ uni-meter {
       udp-restart-backoff = 15s
       min-sample-period = 1ms
 
-      power-offset-total = 0
-      power-offset-l1 = 0
-      power-offset-l2 = 0
-      power-offset-l3 = 0
-      
-      default-client-power-factor = 1.0
-      client-contexts = []
-      
       device {
         type = "SPEM-003CEBEU120"
         mac = ""
@@ -87,20 +92,9 @@ uni-meter {
 
     eco-tracker {
       type = "EcoTracker"
-      forget-interval = 1m
-      default-voltage = 230
-      default-frequency = 50
       
       hostname = ""
       mac = ""
-
-      power-offset-total = 0
-      power-offset-l1 = 0
-      power-offset-l2 = 0
-      power-offset-l3 = 0
-
-      default-client-power-factor = 1.0
-      client-contexts = []
 
       port = 80
       interface = "0.0.0.0"


### PR DESCRIPTION
There is now a configurable delay (usage-constraint-init-duration which default to 60 seconds) were the uni-meter is completely switched off until it changes to the no_charge/no_discharge mode. The intention of this delay is to force the storage into its fallback behavior (no charge/discharge) before the intended behavior is switched on