### PR TITLE
get_parameters: Use ISO-8601 date format with UTC time zone

### DIFF
--- a/src/main/java/com/deigmueller/uni_meter/output/OutputDevice.java
+++ b/src/main/java/com/deigmueller/uni_meter/output/OutputDevice.java
@@ -526,10 +526,10 @@ public abstract class OutputDevice extends AbstractBehavior<OutputDevice.Command
     
     parameters.put("usage-constraint", usageConstraint.name());
     if (Instant.now().isBefore(usageConstraintInitUntil)) {
-      parameters.put("usage-constraint-init-until", dateTimeInfo(usageConstraintInitUntil));
+      parameters.put("usage-constraint-init-until", usageConstraintInitUntil.toString());
     }
     if (Instant.now().isBefore(usageConstraintUntil)) {
-      parameters.put("usage-constraint-until", dateTimeInfo(usageConstraintUntil));
+      parameters.put("usage-constraint-until", usageConstraintUntil.toString());
     }
 
     return parameters;


### PR DESCRIPTION
Use Instant.toString() to have a deterministic and parseable date format.

Closes #359 