### PR TITLE
Add warning about changing the output port for Shelly/Ecotracker

### DIFF
--- a/doc/output/EcoTracker.md
+++ b/doc/output/EcoTracker.md
@@ -41,6 +41,10 @@ uni-meter {
 Please be aware, that the `uni-meter` itself also provides some HTTP functionality on a port which can be configured
 separately. 
 
+> [!WARNING]
+> Some consumers have the target port hardcoded to `80` and cannot be configured to use a custom port. One known
+> example is the Growatt Noah 2000. If you change the port, those consumers might no longer be able to retrieve data.
+
 ## Configuring the MAC address and hostname
 
 It is normally not necessary anymore to configure the MAC address or the hostname. It will be

--- a/doc/output/EcoTracker.md
+++ b/doc/output/EcoTracker.md
@@ -42,8 +42,8 @@ Please be aware, that the `uni-meter` itself also provides some HTTP functionali
 separately. 
 
 > [!WARNING]
-> Some consumers have the target port hardcoded to `80` and cannot be configured to use a custom port. One known
-> example is the Growatt Noah 2000. If you change the port, those consumers might no longer be able to retrieve data.
+> Some consumers have the target port hardcoded to `80` and cannot be configured to use a custom port. Known
+> examples are the Growatt Noah/Nexa 2000 storages. If you change the port, those consumers might no longer be able to retrieve data.
 
 ## Configuring the MAC address and hostname
 

--- a/doc/output/ShellyPro3EM.md
+++ b/doc/output/ShellyPro3EM.md
@@ -85,6 +85,10 @@ uni-meter {
 Please be aware, that the `uni-meter` itself also provides some HTTP functionality on a port which can be configured
 separately. 
 
+> [!WARNING]
+> Some consumers have the target port hardcoded to `80` and cannot be configured to use a custom port. One known
+> example is the Growatt Noah 2000. If you change the port, those consumers might no longer be able to retrieve data.
+
 ## Configuring the Shelly device id
 
 Starting from version 1.1.5 on, it is normally not necessary anymore to configure the Shelly device id. It will be 

--- a/doc/output/ShellyPro3EM.md
+++ b/doc/output/ShellyPro3EM.md
@@ -86,8 +86,8 @@ Please be aware, that the `uni-meter` itself also provides some HTTP functionali
 separately. 
 
 > [!WARNING]
-> Some consumers have the target port hardcoded to `80` and cannot be configured to use a custom port. One known
-> example is the Growatt Noah 2000. If you change the port, those consumers might no longer be able to retrieve data.
+> Some consumers have the target port hardcoded to `80` and cannot be configured to use a custom port. Known
+> examples are the Growatt Noah/Nexa 2000 storages. If you change the port, those consumers might no longer be able to retrieve data.
 
 ## Configuring the Shelly device id
 


### PR DESCRIPTION
Took me a while to realise the Growatt Noah 2000 expects the Shelly Data to be available on port 80.
I also saw now other people were struggling with the same issue: https://github.com/sdeigm/uni-meter/issues/335#issuecomment-4096346026