### PR TITLE
add documentation for iometer input device

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ The real electrical meter data can be gathered from the following input devices:
 - Home Assistant sensors
 - Huawei Inverter (DTSU666-H)
 - ioBroker datapoints (via simple API adapter)
+- IOmeter smart meter
 - Kostal Smart Energy Meter
 - MQTT
 - Powerfox poweropti
@@ -115,6 +116,7 @@ To configure the input device, follow the instructions in these sections:
 * **[Home Assistant](doc/input/HomeAssistant.md)**
 * **[Huawei Inverter](doc/input/Huawei.md)**
 * **[ioBroker](doc/input/IoBroker.md)**
+* **[IOmeter](doc/input/IOmeter.md)**
 * **[Kostal Smart Energy Meter](doc/input/Kostal.md)**
 * **[MQTT](doc/input/Mqtt.md)**
 * **[Powerfox poweropti](doc/input/Poweropti.md)**

--- a/doc/input/IOmeter.md
+++ b/doc/input/IOmeter.md
@@ -1,0 +1,58 @@
+# Using an IOmeter smart meter as the input source
+
+An IOmeter smart meter can be accessed using the generic-http input source. To access the IOmeter, use the following configuration in the uni-meter.conf file:
+
+```hocon
+uni-meter {
+  output = "uni-meter.output-devices.shelly-pro3em"
+
+  input = "uni-meter.input-devices.generic-http"
+
+  input-devices {
+    generic-http {
+      # Adjust the IP address of the ioBroker
+      url = "http://192.168.x.x/v1/reading"
+
+      power-phase-mode = "mono-phase"
+      energy-phase-mode = "mono-phase"
+
+      channels = [{
+        type = "json"
+        channel = "energy-consumption-total"
+        json-path = "$.meter.reading.registers[?(@.obis=='01-00:01.08.00*ff')].value"
+        scale = 0.001
+      },{
+        type = "json"
+        channel = "energy-production-total"
+        json-path = "$.meter.reading.registers[?(@.obis=='01-00:02.08.00*ff')].value"
+        scale = 0.001
+      },{
+        type = "json"
+        channel = "power-total"
+        json-path = "$.meter.reading.registers[?(@.obis=='01-00:10.07.00*ff')].value"
+      }]
+    }
+  }
+}
+```
+
+## Important note about power measurement (10.07 vs 24.07)
+
+Some German smart meters do not provide the current power value under OBIS code 01-00:10.07.00*ff.
+
+Instead, the current power is reported under:
+
+```hocon
+01-00:24.07.00*ff
+```
+
+In such cases, the configured 10.07 channel will return no value, resulting in an incorrect or zero power reading in uni-meter.
+
+## Required configuration change
+
+If your IOmeter device uses OBIS 24.07 instead of 10.07, the configuration must be adjusted accordingly:
+
+```hocon
+channel = "power-total"
+json-path = "$.meter.reading.registers[?(@.obis=='01-00:24.07.00*ff')].value"
+```

--- a/samples/IOmeter/uni-meter.conf
+++ b/samples/IOmeter/uni-meter.conf
@@ -1,0 +1,41 @@
+uni-meter {
+  output = "uni-meter.output-devices.shelly-pro3em"
+
+  input = "uni-meter.input-devices.generic-http"
+
+  http-server {
+    port = 80
+  }
+  
+  output-devices {
+    shelly-pro3em {
+      udp-port = 1010
+      min-sample-period = 2500
+    }
+  }
+
+  input-devices {
+    generic-http {
+      url = "http://10.0.0.4/v1/reading"
+
+      power-phase-mode = "mono-phase"
+      energy-phase-mode = "mono-phase"
+
+      channels = [{
+        type = "json"
+        channel = "energy-consumption-total"
+        json-path = "$.meter.reading.registers[?(@.obis=='01-00:01.08.00*ff')].value"
+        scale = 0.001
+      },{
+        type = "json"
+        channel = "energy-production-total"
+        json-path = "$.meter.reading.registers[?(@.obis=='01-00:02.08.00*ff')].value"
+        scale = 0.001
+      },{
+        type = "json"
+        channel = "power-total"
+        json-path = "$.meter.reading.registers[?(@.obis=='01-00:10.07.00*ff')].value"
+      }]
+    }
+  }
+}


### PR DESCRIPTION
This pull request aims to add documentation for using an IOmeter smart meter with uni-meter to emulate electricity data for supported storage systems.

The IOmeter is a device designed for German electricity meters. It reads electricity data via the meter’s optical interface and exposes it via a local HTTP API.

There is a known device-specific variation in how German smart meters report power data. Most meters provide the current power under OBIS code `01-00:10.07.00*ff`, while some devices instead use `01-00:24.07.00*ff`.

The documentation has been updated accordingly to explain how the configuration file must be adjusted depending on the OBIS codes provided by the specific meter model.