### PR TITLE
Update Smd120.md

### DIFF
--- a/doc/input/Smd120.md
+++ b/doc/input/Smd120.md
@@ -1,18 +1,19 @@
-# Using SMD120 modbus energy meter as the input source
+# Using SDM120 modbus energy meter as the input source
 
-To use a SMD120 modbus energy meter via a Protos PE11 as an input source, set up the `uni-meter.conf` file as
+To use a SDM120 modbus energy meter via a Protos PE11 as an input source, set up the `uni-meter.conf` file as
 follows:
 
 ```hocon
 uni-meter {
   output = "uni-meter.output-devices.shelly-pro3em"
   
-  input = "uni-meter.input-devices.smd120"
+  input = "uni-meter.input-devices.sdm120"
 
   input-devices {
-    smd120 {
+    sdm120 {
+      address = "192.168.x.x"
       port = 8899
-
+      unit-id = 1
       # The Marstek storage needs input data on a single phase. This can be controlled by
       # the configuration options below
       power-phase-mode = "mono-phase"


### PR DESCRIPTION
Device is called SDM120 and als uses sdm120 type.  Added Address and unit ID that are required to quiery modbus Devices over PE11