### PR TITLE
adjust scaling of input data to match expected output data

### DIFF
--- a/doc/input/IOmeter.md
+++ b/doc/input/IOmeter.md
@@ -10,7 +10,7 @@ uni-meter {
 
   input-devices {
     generic-http {
-      # Adjust the IP address of the ioBroker
+      # Adjust the IP address of the IOmeter
       url = "http://192.168.x.x/v1/reading"
 
       power-phase-mode = "mono-phase"
@@ -20,16 +20,17 @@ uni-meter {
         type = "json"
         channel = "energy-consumption-total"
         json-path = "$.meter.reading.registers[?(@.obis=='01-00:01.08.00*ff')].value"
-        scale = 0.001
+        scale = 1
       },{
         type = "json"
         channel = "energy-production-total"
         json-path = "$.meter.reading.registers[?(@.obis=='01-00:02.08.00*ff')].value"
-        scale = 0.001
+        scale = 1
       },{
         type = "json"
         channel = "power-total"
         json-path = "$.meter.reading.registers[?(@.obis=='01-00:10.07.00*ff')].value"
+        scale = 1
       }]
     }
   }

--- a/samples/IOmeter/uni-meter.conf
+++ b/samples/IOmeter/uni-meter.conf
@@ -16,7 +16,7 @@ uni-meter {
 
   input-devices {
     generic-http {
-      url = "http://10.0.0.4/v1/reading"
+      url = "http://192.168.x.x/v1/reading"
 
       power-phase-mode = "mono-phase"
       energy-phase-mode = "mono-phase"
@@ -25,16 +25,17 @@ uni-meter {
         type = "json"
         channel = "energy-consumption-total"
         json-path = "$.meter.reading.registers[?(@.obis=='01-00:01.08.00*ff')].value"
-        scale = 0.001
+        scale = 1
       },{
         type = "json"
         channel = "energy-production-total"
         json-path = "$.meter.reading.registers[?(@.obis=='01-00:02.08.00*ff')].value"
-        scale = 0.001
+        scale = 1
       },{
         type = "json"
         channel = "power-total"
         json-path = "$.meter.reading.registers[?(@.obis=='01-00:10.07.00*ff')].value"
+        scale = 1
       }]
     }
   }


### PR DESCRIPTION
This pull request aims to adjust the scale of the total consumption and production data. Currently our data (Wh) is converted to kWh even though Shelly and ecotracker report the data in Wh according to their documentation as well.