### PR TITLE
Add support for the single phase Shelly Pro EM as an output device

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to the `uni-meter` will be documented in this file.
 
+## [Unreleased]
+
+### Added
+
+- [#382](https://github.com/sdeigm/uni-meter/issues/382) Support for the single phase Shelly Pro EM as an output device
+
 ## [1.5.0] - 2026-04-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Currently, the following output devices are supported:
 
 * Everhome EcoTracker
 * Shelly Pro 3EM
+* Shelly Pro EM (single phase)
 * SMA Energy Meter
 
 The real electrical meter data can be gathered from the following input devices:
@@ -105,6 +106,7 @@ To configure the output device, follow the instructions in these sections:
 * **[Common configuration for all devices](doc/output/Common.md)**
 * **[Eco-Tracker](doc/output/EcoTracker.md)**
 * **[Shelly Pro 3EM](doc/output/ShellyPro3EM.md)**
+* **[Shelly Pro EM](doc/output/ShellyProEM.md)**
 * **[SMA Energy Meter](doc/output/SmaEM.md)**
 
 ## Input device configuration

--- a/doc/output/ShellyProEM.md
+++ b/doc/output/ShellyProEM.md
@@ -1,0 +1,120 @@
+# Configure the Shelly Pro EM output device
+
+The Shelly Pro EM output device emulates the single phase Shelly Pro EM-50. In contrast to the three phase
+Shelly Pro 3EM, this device provides two single phase meters (`EM1` components). Channel `0` reports the summed up
+power and energy data of all input phases, channel `1` is reported as unused.
+
+This output device can be used for consumers which only support single phase Shelly devices or which misinterpret
+the three phase data of the Shelly Pro 3EM.
+
+To use the Shelly Pro EM output device, set up the `uni-meter.conf` file as follows:
+
+```hocon
+uni-meter {
+  output = "uni-meter.output-devices.shelly-proem"
+  
+  # ...
+  output-devices {
+    shelly-proem {
+      # ...
+    }
+  }
+}
+```
+
+Use your browser or the curl utility and open the URL
+
+``http://<uni-meter-ip>/rpc/EM1.GetStatus?id=0``
+
+to check if the virtual shelly is providing the electrical meter readings.
+
+## Enabling JSON RPC over UDP
+
+As a default, the JSON RPC over UDP interface of the Shelly Pro EM emulator is disabled. To enable it, configure the
+`udp-port` and optionally the `udp-interface` in the `/etc/uni-meter.conf` file:
+
+```hocon
+uni-meter {
+  # ...
+  output-devices {
+    shelly-proem {
+      #...
+      udp-port = 1010
+      udp-interface = "0.0.0.0" # default, can be omitted
+      #...
+    }
+  }
+  #...
+}
+```  
+
+## Throttling the sampling frequency of the Shelly device
+
+In some setups with higher latency until the real electrical meter readings are available on the output side, it might
+be necessary to throttle the sampling frequency of the output data. Otherwise, it might be possible that the storage
+oversteers the power production and consumption values and that they are fluctuating too much around 0 (see the comments
+and findings to this [issue](https://github.com/sdeigm/uni-meter/issues/12)).
+
+To throttle the sampling frequency, you can configure a `min-sample-period` in the `/etc/uni-meter.conf` file. This
+configuration value specifies the minimum time until the next output data is delivered to the storage.
+
+```hocon
+uni-meter {
+  #...
+  output-devices {
+    shelly-proem {
+      #...
+      min-sample-period = 5000ms
+      #...
+    }
+  }
+  #...
+}
+```
+
+## Changing the HTTP server port
+
+In its default configuration, the emulated Shelly Pro EM listens on port 80 for incoming HTTP requests. That port can 
+be changed to for instance port 4711 by adding the following parts to your `/etc/uni-meter.conf` file:
+
+```hocon
+uni-meter {
+  # ...
+  output-devices {
+    shelly-proem {
+      # ...
+      port = 4711
+    }
+  }
+}
+```
+
+Please be aware, that the `uni-meter` itself also provides some HTTP functionality on a port which can be configured
+separately. 
+
+> [!WARNING]
+> Some consumers have the target port hardcoded to `80` and cannot be configured to use a custom port. If you change
+> the port, those consumers might no longer be able to retrieve data.
+
+## Configuring the Shelly device id
+
+Normally it is not necessary to configure the Shelly device id. It will be automatically set based on the first
+detected hardware mac address on the host machine.
+
+If it may, for whatever reason, be necessary to modify the device id, it can be done using the following configuration
+parameters:
+
+```hocon
+uni-meter {
+  # ...
+  output-devices {
+    shelly-proem {
+      device {
+        mac = "B827EB364242"
+        hostname = "shellyproem50-b827eb364242"
+      }
+    }
+  }
+  #...
+}
+```

--- a/src/main/java/com/deigmueller/uni_meter/application/UniMeter.java
+++ b/src/main/java/com/deigmueller/uni_meter/application/UniMeter.java
@@ -20,6 +20,7 @@ import com.deigmueller.uni_meter.mdns.MDnsRegistrator;
 import com.deigmueller.uni_meter.output.OutputDevice;
 import com.deigmueller.uni_meter.output.device.eco_tracker.EcoTracker;
 import com.deigmueller.uni_meter.output.device.shelly.ShellyPro3EM;
+import com.deigmueller.uni_meter.output.device.shelly.ShellyProEM;
 import com.deigmueller.uni_meter.output.device.sma_em.SmaEM;
 import com.typesafe.config.Config;
 import org.apache.pekko.actor.typed.ActorRef;
@@ -145,6 +146,17 @@ public class UniMeter extends AbstractBehavior<UniMeter.Command> {
         return getContext().spawn(
               Behaviors.supervise(
                     ShellyPro3EM.create(
+                          getContext().getSelf(),
+                          mDnsRegistrator,
+                          config)
+              ).onFailure(failureStrategy),
+              "output");
+      }
+      case ShellyProEM.TYPE -> {
+        logger.info("creating ShellyProEM output device");
+        return getContext().spawn(
+              Behaviors.supervise(
+                    ShellyProEM.create(
                           getContext().getSelf(),
                           mDnsRegistrator,
                           config)

--- a/src/main/java/com/deigmueller/uni_meter/common/shelly/Rpc.java
+++ b/src/main/java/com/deigmueller/uni_meter/common/shelly/Rpc.java
@@ -99,6 +99,10 @@ public class Rpc {
         case "em.getstatus" -> objectMapper.treeToValue(tree, EmGetStatus.class);
         case "emdata.getconfig" -> objectMapper.treeToValue(tree, EmDataGetConfig.class);
         case "emdata.getstatus" -> objectMapper.treeToValue(tree, EmDataGetStatus.class);
+        case "em1.getconfig" -> objectMapper.treeToValue(tree, Em1GetConfig.class);
+        case "em1.getstatus" -> objectMapper.treeToValue(tree, Em1GetStatus.class);
+        case "em1data.getconfig" -> objectMapper.treeToValue(tree, Em1DataGetConfig.class);
+        case "em1data.getstatus" -> objectMapper.treeToValue(tree, Em1DataGetStatus.class);
         case "script.list" -> objectMapper.treeToValue(tree, ScriptList.class);
         case "script.getcode" -> objectMapper.treeToValue(tree, ScriptGetCode.class);
         case "shelly.getcomponents" -> objectMapper.treeToValue(tree, ShellyGetComponents.class);
@@ -586,6 +590,120 @@ public class Rpc {
         @JsonProperty("c_total_act_ret_energy") Double c_total_act_ret_energy,
         @JsonProperty("total_act") Double total_act,
         @JsonProperty("total_act_ret") Double total_act_ret,
+        @JsonProperty("errors") String[] errors
+  ) implements Response, Status {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Em1GetStatus(
+        @JsonProperty("id") Long id,
+        @JsonProperty("method") String method,
+        @JsonProperty("src") String src,
+        @JsonProperty("dst") String dst,
+        @JsonProperty("params") Em1GetStatusParams params
+  ) implements Request {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Em1GetStatusParams(
+        @JsonProperty("id") int id
+  ) {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"id", "current", "voltage", "act_power", "aprt_power", "pf", "freq", "calibration", "errors",
+                     "flags"})
+  public record Em1GetStatusResponse(
+        @JsonProperty("id") Integer id,
+        @JsonProperty("current") Double current,
+        @JsonProperty("voltage") Double voltage,
+        @JsonProperty("act_power") Double act_power,
+        @JsonProperty("aprt_power") Double aprt_power,
+        @JsonProperty("pf") Double pf,
+        @JsonProperty("freq") Double freq,
+        @JsonProperty("calibration") String calibration,
+        @JsonProperty("errors") List<String> errors,
+        @JsonProperty("flags") List<String> flags
+  ) implements Response, Status {
+    @Override public @NotNull String toString() { return Rpc.toString(this); }
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Em1GetConfig(
+        @JsonProperty("id") Long id,
+        @JsonProperty("method") String method,
+        @JsonProperty("src") String src,
+        @JsonProperty("dst") String dst,
+        @JsonProperty("params") Em1GetConfigParams params
+  ) implements Request {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Em1GetConfigParams(
+        @JsonProperty("id") int id
+  ) {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"id", "name", "reverse", "ct_type"})
+  public record Em1GetConfigResponse(
+        @JsonProperty("id") Integer id,
+        @JsonProperty("name") RpcStringOrNull name,
+        @JsonProperty("reverse") Boolean reverse,
+        @JsonProperty("ct_type") String ct_type
+  ) implements Response, Config {
+    @Override public @NotNull String toString() { return Rpc.toString(this); }
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"ts", "em1:0"})
+  public record Em1GetStatusNotification(
+        @JsonProperty("ts") Double ts,
+        @JsonProperty("em1:0") Em1GetStatusResponse em10
+  ) implements NotificationParam {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"id", "method", "src", "dst", "params"})
+  public record Em1DataGetConfig(
+        @JsonProperty("id") Long id,
+        @JsonProperty("method") String method,
+        @JsonProperty("src") String src,
+        @JsonProperty("dst") String dst,
+        @JsonProperty("params") Em1DataGetStatusParams params) implements Request {
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Em1DataGetConfigResponse(
+  ) implements Response, Config {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"id", "method", "src", "dst", "params"})
+  public record Em1DataGetStatus(
+        @JsonProperty("id") Long id,
+        @JsonProperty("method") String method,
+        @JsonProperty("src") String src,
+        @JsonProperty("dst") String dst,
+        @JsonProperty("params") Em1DataGetStatusParams params) implements Request {
+  }
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public record Em1DataGetStatusParams(
+        @JsonProperty("id") int id
+  ) {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  @JsonPropertyOrder({"id", "total_act_energy", "total_act_ret_energy", "errors"})
+  public record Em1DataGetStatusResponse(
+        @JsonProperty("id") long id,
+        @JsonProperty("total_act_energy") Double total_act_energy,
+        @JsonProperty("total_act_ret_energy") Double total_act_ret_energy,
         @JsonProperty("errors") String[] errors
   ) implements Response, Status {}
 

--- a/src/main/java/com/deigmueller/uni_meter/output/device/shelly/HttpRoute.java
+++ b/src/main/java/com/deigmueller/uni_meter/output/device/shelly/HttpRoute.java
@@ -40,20 +40,23 @@ class HttpRoute extends AllDirectives {
   private final Materializer materializer;
   private final ActorRef<OutputDevice.Command> shelly;
   private final ActorRef<WebsocketInput.Notification> websocketInput;
+  private final boolean em1Support;
   private final Duration timeout = Duration.ofSeconds(5);
   private final FiniteDuration finiteTimeout = FiniteDuration.apply(5, TimeUnit.SECONDS);
   private final ObjectMapper objectMapper = Rpc.createObjectMapper();
-  
-  public HttpRoute(Logger logger, 
-                   ActorSystem<?> system, 
+
+  public HttpRoute(Logger logger,
+                   ActorSystem<?> system,
                    Materializer materializer,
                    ActorRef<OutputDevice.Command> shelly,
-                   ActorRef<WebsocketInput.Notification> websocketInput) {
+                   ActorRef<WebsocketInput.Notification> websocketInput,
+                   boolean em1Support) {
     this.logger = logger;
     this.system = system;
     this.materializer = materializer;
     this.shelly = shelly;
     this.websocketInput = websocketInput;
+    this.em1Support = em1Support;
   }
 
   public Route createRoute() {
@@ -98,8 +101,28 @@ class HttpRoute extends AllDirectives {
                                               onEmDataGetConfig(id.orElse(0)))
                                   ),
                                   path("EMData.GetStatus", () ->
-                                        parameterOptional(StringUnmarshallers.INTEGER, "id", id -> 
+                                        parameterOptional(StringUnmarshallers.INTEGER, "id", id ->
                                               onEmDataGetStatus(remoteAddress, id.orElse(0)))
+                                  ),
+                                  path("EM1.GetConfig", () -> em1Support
+                                        ? parameterOptional(StringUnmarshallers.INTEGER, "id", id ->
+                                              onEm1GetConfig(id.orElse(0)))
+                                        : reject()
+                                  ),
+                                  path("EM1.GetStatus", () -> em1Support
+                                        ? parameterOptional(StringUnmarshallers.INTEGER, "id", id ->
+                                              onEm1GetStatus(remoteAddress, id.orElse(0)))
+                                        : reject()
+                                  ),
+                                  path("EM1Data.GetConfig", () -> em1Support
+                                        ? parameterOptional(StringUnmarshallers.INTEGER, "id", id ->
+                                              onEm1DataGetConfig(id.orElse(0)))
+                                        : reject()
+                                  ),
+                                  path("EM1Data.GetStatus", () -> em1Support
+                                        ? parameterOptional(StringUnmarshallers.INTEGER, "id", id ->
+                                              onEm1DataGetStatus(remoteAddress, id.orElse(0)))
+                                        : reject()
                                   ),
                                   path("Script.List", () ->
                                         onScripList(remoteAddress)
@@ -272,7 +295,7 @@ class HttpRoute extends AllDirectives {
     return completeOKWithFuture(
           AskPattern.ask(
                 shelly,
-                (ActorRef<ShellyPro3EM.ShellyConfig> replyTo) -> new ShellyPro3EM.ShellyGetConfig(
+                (ActorRef<Rpc.Response> replyTo) -> new ShellyPro3EM.ShellyGetConfig(
                       remoteAddress.getAddress().orElse(DEFAULT_ADDRESS),
                       replyTo),
                 timeout,
@@ -300,7 +323,7 @@ class HttpRoute extends AllDirectives {
     return completeOKWithFuture(
           AskPattern.ask(
                 shelly,
-                (ActorRef<Rpc.ShellyGetStatusResponse> replyTo) -> new ShellyPro3EM.ShellyGetStatus(
+                (ActorRef<Rpc.Response> replyTo) -> new ShellyPro3EM.ShellyGetStatus(
                       remoteAddress.getAddress().orElse(DEFAULT_ADDRESS),
                       replyTo),
                 timeout,
@@ -468,6 +491,94 @@ class HttpRoute extends AllDirectives {
                       new ShellyPro3EM.EmDataGetStatus(
                             remoteAddress.getAddress().orElse(DEFAULT_ADDRESS), 
                             id, 
+                            replyTo),
+                timeout,
+                system.scheduler()
+          ).thenApply(response -> {
+            if (response.failure() != null) {
+              throw response.failure();
+            }
+
+            return response.status();
+          }),
+          Jackson.marshaller(objectMapper));
+  }
+
+  private Route onEm1GetConfig(int id) {
+    logger.trace("HttpRoute.onEm1GetConfig({})", id);
+    return completeOKWithFuture(
+          AskPattern.ask(
+                shelly,
+                (ActorRef<ShellyProEM.Em1GetConfigOrFailureResponse> replyTo) -> new ShellyProEM.Em1GetConfig(id, replyTo),
+                timeout,
+                system.scheduler()
+          ).thenApply(response -> {
+            if (response.failure() != null) {
+              throw response.failure();
+            }
+
+            return response.status();
+          }),
+          Jackson.marshaller(objectMapper));
+  }
+
+  private Route onEm1GetStatus(@NotNull RemoteAddress remoteAddress,
+                               int id) {
+    logger.trace("HttpRoute.onEm1GetStatus({}, {})", remoteAddress, id);
+    return completeOKWithFuture(
+          AskPattern.ask(
+                shelly,
+                (ActorRef<ShellyProEM.Em1GetStatusOrFailureResponse> replyTo) ->
+                      new ShellyProEM.Em1GetStatus(
+                            remoteAddress.getAddress().orElse(DEFAULT_ADDRESS),
+                            id,
+                            replyTo),
+                timeout,
+                system.scheduler()
+          ).thenApply(response -> {
+            if (response.failure() != null) {
+              if (response.failure() instanceof RuntimeException runtimeException) {
+                throw runtimeException;
+              }
+              throw new RuntimeException(response.failure());
+            }
+
+            return response.status();
+          }),
+          Jackson.marshaller(objectMapper));
+  }
+
+  private Route onEm1DataGetConfig(int id) {
+    logger.trace("HttpRoute.onEm1DataGetConfig({})", id);
+    return completeOKWithFuture(
+          AskPattern.ask(
+                shelly,
+                (ActorRef<ShellyProEM.Em1DataGetConfigOrFailureResponse> replyTo) ->
+                      new ShellyProEM.Em1DataGetConfig(
+                            id,
+                            replyTo),
+                timeout,
+                system.scheduler()
+          ).thenApply(response -> {
+            if (response.failure() != null) {
+              throw response.failure();
+            }
+
+            return response.status();
+          }),
+          Jackson.marshaller(objectMapper));
+  }
+
+  private Route onEm1DataGetStatus(@NotNull RemoteAddress remoteAddress,
+                                   int id) {
+    logger.trace("HttpRoute.onEm1DataGetStatus({}, {})", remoteAddress, id);
+    return completeOKWithFuture(
+          AskPattern.ask(
+                shelly,
+                (ActorRef<ShellyProEM.Em1DataGetStatusOrFailureResponse> replyTo) ->
+                      new ShellyProEM.Em1DataGetStatus(
+                            remoteAddress.getAddress().orElse(DEFAULT_ADDRESS),
+                            id,
                             replyTo),
                 timeout,
                 system.scheduler()

--- a/src/main/java/com/deigmueller/uni_meter/output/device/shelly/Shelly.java
+++ b/src/main/java/com/deigmueller/uni_meter/output/device/shelly/Shelly.java
@@ -235,8 +235,12 @@ public abstract class Shelly extends OutputDevice {
     if (! StringUtils.isAllBlank(config.getString("device.hostname"))) {
       return config.getString("device.hostname");
     }
-    
-    return "ShellyPro3EM-" + mac.toUpperCase();
+
+    String prefix = config.hasPath("device.hostname-prefix")
+          ? config.getString("device.hostname-prefix")
+          : "ShellyPro3EM-";
+
+    return prefix + mac.toUpperCase();
   }
   
   public record ShellyGet(

--- a/src/main/java/com/deigmueller/uni_meter/output/device/shelly/ShellyPro3EM.java
+++ b/src/main/java/com/deigmueller/uni_meter/output/device/shelly/ShellyPro3EM.java
@@ -691,7 +691,7 @@ public class ShellyPro3EM extends Shelly {
 
     Rpc.Request request = Rpc.parseRequest(text);
 
-    if ("EM.GetStatus".equals(request.method())) {
+    if (isThrottledStatusRequest(request.method())) {
       websocketContext.handleEmGetStatusRequest(request);
       if (websocketThrottlingQueue != null) {
         websocketThrottlingQueue.offer(new WebsocketProcessPendingEmGetStatusRequest(websocketContext, wsMessage));
@@ -863,7 +863,7 @@ public class ShellyPro3EM extends Shelly {
 
     Rpc.Request request = Rpc.parseRequest(text);
 
-    if ("EM.GetStatus".equals(request.method())) {
+    if (isThrottledStatusRequest(request.method())) {
       udpClientContext.handleEmGetStatusRequest(request);
       if (udpThrottlingQueue != null) {
         udpThrottlingQueue.offer(new UdpClientProcessPendingEmGetStatusRequest(udpClientContext, message.datagram()));
@@ -934,6 +934,27 @@ public class ShellyPro3EM extends Shelly {
   }
 
   /**
+   * Check whether the specified RPC method is a power status request which is throttled
+   * using the configured min-sample-period
+   * @param method RPC method name
+   * @return True if the request is a throttled status request
+   */
+  protected boolean isThrottledStatusRequest(@NotNull String method) {
+    return "EM.GetStatus".equals(method);
+  }
+
+  /**
+   * Create the parameters of the NotifyStatus notification sent over the outbound websocket connection
+   * @return Parameters of the NotifyStatus notification
+   */
+  protected Rpc.NotificationParam createNotifyStatusParam() throws RpcException {
+    return new Rpc.EmGetStatusNotification(
+          Instant.now().toEpochMilli() / 1000.0,
+          rpcEmGetStatus(1.0)
+    );
+  }
+
+  /**
    * Handle the event that the power data has changed
    */
   @Override
@@ -946,10 +967,7 @@ public class ShellyPro3EM extends Shelly {
                 getHostname(outboundWebsocketAddress),
                 null,
                 "NotifyStatus",
-                new Rpc.EmGetStatusNotification(
-                      Instant.now().toEpochMilli() / 1000.0,
-                      rpcEmGetStatus(1.0)
-                )
+                createNotifyStatusParam()
           );
 
           outboundWebsocketContext.getOutput().tell(
@@ -976,9 +994,18 @@ public class ShellyPro3EM extends Shelly {
             getContext().getSystem(),
             getMaterializer(),
             getContext().getSelf(),
-            websocketInputNotificationAdapter);
-    
+            websocketInputNotificationAdapter,
+            supportsEm1());
+
     return httpRoute.createRoute();
+  }
+
+  /**
+   * Check whether the device provides EM1/EM1Data components (single phase meters)
+   * @return True if the device provides EM1/EM1Data components
+   */
+  protected boolean supportsEm1() {
+    return false;
   }
 
   @Override
@@ -1049,7 +1076,7 @@ public class ShellyPro3EM extends Shelly {
    * Handle the request to get the config of the Ble component
    * @return Config of the Ble component
    */
-  private Rpc.BleGetConfigResponse rpcBleGetConfig() {
+  protected Rpc.BleGetConfigResponse rpcBleGetConfig() {
     logger.trace("ShellyPro3EM.rpcBleGetConfig()");
     return new Rpc.BleGetConfigResponse(true, new Rpc.BleGetConfigResponseRpc(true), null);
   }
@@ -1058,7 +1085,7 @@ public class ShellyPro3EM extends Shelly {
    * Handle the request to get the status of the Ble component
    * @return Status of the Ble component
    */
-  private Rpc.BleGetStatusResponse rpcBleGetStatus() {
+  protected Rpc.BleGetStatusResponse rpcBleGetStatus() {
     logger.trace("ShellyPro3EM.rpcBleGetStatus()");
     return new Rpc.BleGetStatusResponse();
   }
@@ -1067,7 +1094,7 @@ public class ShellyPro3EM extends Shelly {
    * Handle the request to get the status of the BtHome component
    * @return Status of the BtHome component
    */
-  private Rpc.BtHomeGetStatusResponse rpcBtHomeGetStatus() {
+  protected Rpc.BtHomeGetStatusResponse rpcBtHomeGetStatus() {
     logger.trace("ShellyPro3EM.rpcBtHomeGetStatus()");
     return new Rpc.BtHomeGetStatusResponse();
   }
@@ -1099,19 +1126,19 @@ public class ShellyPro3EM extends Shelly {
     return new Rpc.ScriptGetCodeResponse("", 0);
   }
 
-  private Rpc.ShellyGetComponentsResponse rpcShellyGetComponents(@NotNull InetAddress remoteAddress) {
+  protected Rpc.ShellyGetComponentsResponse rpcShellyGetComponents(@NotNull InetAddress remoteAddress) {
     logger.trace("Shelly.rpcShellyGetComponents()");
     return createComponents(remoteAddress);
   }
 
-  private ShellyConfig rpcShellyGetConfig(@NotNull InetAddress remoteAddress) {
+  protected Rpc.Response rpcShellyGetConfig(@NotNull InetAddress remoteAddress) {
     logger.trace("Shelly.rpcShellyGetConfig()");
     return createConfig(remoteAddress);
   }
 
-  private Rpc.ShellyGetStatusResponse rpcShellyGetStatus(@NotNull InetAddress remoteAddress) {
+  protected Rpc.Response rpcShellyGetStatus(@NotNull InetAddress remoteAddress) {
     logger.trace("Shelly.rpcShellyGetStatus()");
-    
+
     Rpc.ShellyGetStatusResponse response = new Rpc.ShellyGetStatusResponse(
           rpcBleGetStatus(),
           rpcBtHomeGetStatus(),
@@ -1132,7 +1159,7 @@ public class ShellyPro3EM extends Shelly {
     return response;
   }
 
-  private Rpc.GetDeviceInfoResponse rpcGetDeviceInfo(@NotNull InetAddress remoteAddress) {
+  protected Rpc.GetDeviceInfoResponse rpcGetDeviceInfo(@NotNull InetAddress remoteAddress) {
     logger.trace("Shelly.rpcGetDeviceInfo()");
 
     Rpc.GetDeviceInfoResponse response = new Rpc.GetDeviceInfoResponse(
@@ -1155,7 +1182,7 @@ public class ShellyPro3EM extends Shelly {
     return response;
   }
   
-  private Rpc.ShellyRebootResponse rpcReboot(@NotNull InetAddress ignore) {
+  protected Rpc.ShellyRebootResponse rpcReboot(@NotNull InetAddress ignore) {
     logger.trace("ShellyPro3EM.rpcReboot()");
     return new Rpc.ShellyRebootResponse();
   }
@@ -1164,7 +1191,7 @@ public class ShellyPro3EM extends Shelly {
    * Get the cloud configuration
    * @return Cloud configuration
    */
-  private Rpc.CloudGetConfigResponse rpcCloudGetConfig() {
+  protected Rpc.CloudGetConfigResponse rpcCloudGetConfig() {
     logger.trace("ShellyPro3EM.rpcCloudGetConfig()");
     return cloudConfig;
   }
@@ -1173,12 +1200,12 @@ public class ShellyPro3EM extends Shelly {
    * Get the cloud status
    * @return Cloud status
    */
-  private Rpc.CloudGetStatusResponse rpcCloudGetStatus() {
+  protected Rpc.CloudGetStatusResponse rpcCloudGetStatus() {
     logger.trace("ShellyPro3EM.rpcCloudGetStatus()");
     return new Rpc.CloudGetStatusResponse(getConfig().getConfig("cloud"));
   }
   
-  private Rpc.EmGetConfigResponse rpcEmGetConfig() {
+  protected Rpc.EmGetConfigResponse rpcEmGetConfig() {
     logger.trace("ShellyPro3EM.rpcEmGetConfig()");
     
     return new Rpc.EmGetConfigResponse(
@@ -1193,7 +1220,7 @@ public class ShellyPro3EM extends Shelly {
   }
   
 
-  private Rpc.EmGetStatusResponse rpcEmGetStatus(double factor) throws RpcException {
+  protected Rpc.EmGetStatusResponse rpcEmGetStatus(double factor) throws RpcException {
     logger.trace("ShellyPro3EM.rpcEmGetStatus()");
     
     if (isSwitchedOff()) {
@@ -1257,12 +1284,12 @@ public class ShellyPro3EM extends Shelly {
     );
   }
   
-  private Rpc.EmDataGetConfigResponse rpcEmDataGetConfig() {
+  protected Rpc.EmDataGetConfigResponse rpcEmDataGetConfig() {
     logger.trace("ShellyPro3EM.rpcEmDataGetConfig()");
     return new Rpc.EmDataGetConfigResponse();
   }
 
-  private Rpc.EmDataGetStatusResponse rpcEmDataGetStatus() {
+  protected Rpc.EmDataGetStatusResponse rpcEmDataGetStatus() {
     logger.trace("ShellyPro3EM.rpcEmDataGetStatus()");
 
     if (isSwitchedOff()) {
@@ -1310,7 +1337,7 @@ public class ShellyPro3EM extends Shelly {
    * Get the status of the Eth component
    * @return Status of the Eth component
    */
-  private Rpc.EthGetStatusResponse rpcEthGetStatus() {
+  protected Rpc.EthGetStatusResponse rpcEthGetStatus() {
     logger.trace("ShellyPro3EM.rpcEthGetStatus()");
     return new Rpc.EthGetStatusResponse(Rpc.RpcStringOrNull.of(null), Rpc.RpcStringOrNull.of(null));
   }
@@ -1319,7 +1346,7 @@ public class ShellyPro3EM extends Shelly {
    * Get the status of the Modbus component
    * @return Status of the Modbus component
    */
-  private Rpc.ModbusGetStatusResponse rpcModbusGetStatus() {
+  protected Rpc.ModbusGetStatusResponse rpcModbusGetStatus() {
     logger.trace("ShellyPro3EM.rpcModbusGetStatus()");
     return new Rpc.ModbusGetStatusResponse();
   }
@@ -1328,12 +1355,12 @@ public class ShellyPro3EM extends Shelly {
    * Get the status of the Mqtt component
    * @return Status of the Mqtt component
    */
-  private Rpc.MqttGetStatusResponse rpcMqttGetStatus() {
+  protected Rpc.MqttGetStatusResponse rpcMqttGetStatus() {
     logger.trace("ShellyPro3EM.rpcMqttGetStatus()");
     return new Rpc.MqttGetStatusResponse(false);
   }
 
-  private Rpc.SysGetConfigResponse rpcSysGetConfig(@NotNull InetAddress remoteAddress) {
+  protected Rpc.SysGetConfigResponse rpcSysGetConfig(@NotNull InetAddress remoteAddress) {
     logger.trace("ShellyPro3EM.rpcSysGetConfig()");
     
     return new Rpc.SysGetConfigResponse(
@@ -1364,7 +1391,7 @@ public class ShellyPro3EM extends Shelly {
     );
   }
 
-  private Rpc.SysGetStatusResponse rpcSysGetStatus(@NotNull InetAddress remoteAddress) {
+  protected Rpc.SysGetStatusResponse rpcSysGetStatus(@NotNull InetAddress remoteAddress) {
     logger.trace("ShellyPro3EM.rpcSysGetStatus()");
     
     return new Rpc.SysGetStatusResponse(
@@ -1392,12 +1419,12 @@ public class ShellyPro3EM extends Shelly {
     );
   }
   
-  private Rpc.TemperatureGetStatusResponse rpcTemperatureGetStatus() {
+  protected Rpc.TemperatureGetStatusResponse rpcTemperatureGetStatus() {
     logger.trace("ShellyPro3EM.rpcTemperatureGetStatus()");
     return new Rpc.TemperatureGetStatusResponse(0, 39.1, 102.4);
   }
 
-  private Rpc.TemperatureGetConfigResponse rpcTemperatureGetConfig() {
+  protected Rpc.TemperatureGetConfigResponse rpcTemperatureGetConfig() {
     logger.trace("ShellyPro3EM.rpcTemperatureGetConfig()");
     return new Rpc.TemperatureGetConfigResponse(
           0,
@@ -1407,7 +1434,7 @@ public class ShellyPro3EM extends Shelly {
     );
   }
 
-  private Rpc.WifiGetConfigResponse rpcWifiGetConfig() {
+  protected Rpc.WifiGetConfigResponse rpcWifiGetConfig() {
     logger.trace("ShellyPro3EM.rpcWifiGetConfig()");
     return new Rpc.WifiGetConfigResponse(
           new Rpc.AccessPointConfig(
@@ -1443,7 +1470,7 @@ public class ShellyPro3EM extends Shelly {
     );
   }
 
-  private Rpc.WifiGetStatusResponse rpcWifiGetStatus() {
+  protected Rpc.WifiGetStatusResponse rpcWifiGetStatus() {
     logger.trace("ShellyPro3EM.rpcWifiGetStatus()");
     return new Rpc.WifiGetStatusResponse(
           NetUtils.detectPrimaryIpAddress(),
@@ -1459,7 +1486,7 @@ public class ShellyPro3EM extends Shelly {
    * Get the outgoing websocket configuration
    * @return Outgoing websocket configuration
    */
-  private Rpc.WsGetConfigResponse rpcWsGetConfig() {
+  protected Rpc.WsGetConfigResponse rpcWsGetConfig() {
     logger.trace("ShellyPro3EM.rpcWsGetConfig()");
     return wsConfig;
   }
@@ -1483,7 +1510,7 @@ public class ShellyPro3EM extends Shelly {
    * Get the outgoing websocket configuration
    * @return Outgoing websocket configuration
    */
-  private Rpc.WsGetStatusResponse rpcWsGetStatus() {
+  protected Rpc.WsGetStatusResponse rpcWsGetStatus() {
     logger.trace("ShellyPro3EM.rpcWsGetStatus()");
     return new Rpc.WsGetStatusResponse(false);
   }
@@ -1540,7 +1567,7 @@ public class ShellyPro3EM extends Shelly {
    * Create the device's component list
    * @return Device's component list
    */
-  private Rpc.ShellyGetComponentsResponse createComponents(@NotNull InetAddress remoteAddress) {
+  protected Rpc.ShellyGetComponentsResponse createComponents(@NotNull InetAddress remoteAddress) {
     return new Rpc.ShellyGetComponentsResponse(
           List.of(
                 new Rpc.Component("ble", rpcBleGetStatus(), rpcBleGetConfig()),
@@ -1557,7 +1584,7 @@ public class ShellyPro3EM extends Shelly {
    * Create the device's status
    * @return Device's status
    */
-  private ShellyConfig createConfig(@NotNull InetAddress remoteAddress) {
+  protected Rpc.Response createConfig(@NotNull InetAddress remoteAddress) {
     return new ShellyConfig(
           new Rpc.BleGetConfigResponse(
                 false, 
@@ -1572,7 +1599,7 @@ public class ShellyPro3EM extends Shelly {
     );
   }
   
-  private Rpc.Response rpcUnknownMethod(Rpc.Request request) {
+  protected Rpc.Response rpcUnknownMethod(Rpc.Request request) {
     logger.error("ShellyPro3EM.rpcUnknownMethod()");
     throw new IllegalArgumentException("unhandled RPC method '" + request.method() + "'");
   }
@@ -1834,7 +1861,7 @@ public class ShellyPro3EM extends Shelly {
 
   public record ShellyGetConfig(
         @JsonProperty("remoteAddress") InetAddress remoteAddress,
-        @JsonProperty("replyTo") ActorRef<ShellyPro3EM.ShellyConfig> replyTo
+        @JsonProperty("replyTo") ActorRef<Rpc.Response> replyTo
   ) implements Command {}
 
   public record ShellyGetDeviceInfo(
@@ -1844,7 +1871,7 @@ public class ShellyPro3EM extends Shelly {
 
   public record ShellyGetStatus(
         @JsonProperty("remoteAddress") InetAddress remoteAddress,
-        @JsonProperty("replyTo") ActorRef<Rpc.ShellyGetStatusResponse> replyTo
+        @JsonProperty("replyTo") ActorRef<Rpc.Response> replyTo
   ) implements Command {}
   
   public record ShellyReboot(

--- a/src/main/java/com/deigmueller/uni_meter/output/device/shelly/ShellyProEM.java
+++ b/src/main/java/com/deigmueller/uni_meter/output/device/shelly/ShellyProEM.java
@@ -1,0 +1,556 @@
+package com.deigmueller.uni_meter.output.device.shelly;
+
+import com.deigmueller.uni_meter.application.UniMeter;
+import com.deigmueller.uni_meter.common.shelly.Rpc;
+import com.deigmueller.uni_meter.common.shelly.RpcError;
+import com.deigmueller.uni_meter.common.shelly.RpcException;
+import com.deigmueller.uni_meter.mdns.MDnsRegistrator;
+import com.deigmueller.uni_meter.output.TemporaryNotAvailableException;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.typesafe.config.Config;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.apache.pekko.actor.typed.Behavior;
+import org.apache.pekko.actor.typed.javadsl.ActorContext;
+import org.apache.pekko.actor.typed.javadsl.Behaviors;
+import org.apache.pekko.actor.typed.javadsl.ReceiveBuilder;
+import org.jetbrains.annotations.NotNull;
+
+import java.net.InetAddress;
+import java.time.Instant;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * Emulation of a Shelly Pro EM-50 (SPEM-002CEBEU50), the single phase variant of the Shelly Pro 3EM. The
+ * device provides two single phase meters (EM1/EM1Data components). Channel 0 reports the summed up power
+ * and energy data of all input phases, channel 1 is reported as unused.
+ */
+public class ShellyProEM extends ShellyPro3EM {
+  // Class members
+  public static final String TYPE = "ShellyProEM";
+
+  /**
+   * Static setup method
+   * @param controller Controller actor reference
+   * @param mDnsRegistrator mDNS registration actor
+   * @param config Output device configuration
+   * @return Behavior of the created actor
+   */
+  public static Behavior<Command> create(@NotNull ActorRef<UniMeter.Command> controller,
+                                         @NotNull ActorRef<MDnsRegistrator.Command> mDnsRegistrator,
+                                         @NotNull Config config) {
+    return Behaviors.setup(context -> new ShellyProEM(context, controller, mDnsRegistrator, config));
+  }
+
+  /**
+   * Protected constructor called by the static setup method
+   * @param context Actor context
+   * @param controller Controller actor reference
+   * @param mDnsRegistrator mDNS registration actor
+   * @param config Output device configuration
+   */
+  protected ShellyProEM(@NotNull ActorContext<Command> context,
+                        @NotNull ActorRef<UniMeter.Command> controller,
+                        @NotNull ActorRef<MDnsRegistrator.Command> mDnsRegistrator,
+                        @NotNull Config config) {
+    super(context, controller, mDnsRegistrator, config);
+  }
+
+  @Override
+  public @NotNull ReceiveBuilder<Command> newReceiveBuilder() {
+    return super.newReceiveBuilder()
+          .onMessage(Em1GetConfig.class, this::onEm1GetConfig)
+          .onMessage(Em1GetStatus.class, this::onEm1GetStatus)
+          .onMessage(Em1DataGetConfig.class, this::onEm1DataGetConfig)
+          .onMessage(Em1DataGetStatus.class, this::onEm1DataGetStatus);
+  }
+
+  @Override
+  protected boolean supportsEm1() {
+    return true;
+  }
+
+  @Override
+  protected boolean isThrottledStatusRequest(@NotNull String method) {
+    return super.isThrottledStatusRequest(method) || "EM1.GetStatus".equals(method);
+  }
+
+  @Override
+  protected int getNumMeters() {
+    return 2;
+  }
+
+  /**
+   * Handle the EM1.GetStatus HTTP request
+   * @param request Request to get the EM1 status
+   * @return Same behavior
+   */
+  protected @NotNull Behavior<Command> onEm1GetStatus(@NotNull Em1GetStatus request) {
+    logger.trace("ShellyProEM.onEm1GetStatus()");
+
+    if (isEm1Channel(request.id())) {
+      try {
+        request.replyTo().tell(
+              new Em1GetStatusOrFailureResponse(
+                    null,
+                    rpcEm1GetStatus(request.id(), getPowerFactorForRemoteAddress(request.remoteAddress()))));
+      } catch (Exception e) {
+        request.replyTo().tell(new Em1GetStatusOrFailureResponse(e, null));
+      }
+    } else {
+      request.replyTo().tell(
+            new Em1GetStatusOrFailureResponse(
+                  new NoSuchElementException("unknown EM1 with id " + request.id()),
+                  null));
+    }
+
+    return Behaviors.same();
+  }
+
+  /**
+   * Handle the EM1.GetConfig HTTP request
+   * @param request Request to get the EM1 configuration
+   * @return Same behavior
+   */
+  protected @NotNull Behavior<Command> onEm1GetConfig(@NotNull Em1GetConfig request) {
+    logger.trace("ShellyProEM.onEm1GetConfig()");
+
+    if (isEm1Channel(request.id())) {
+      request.replyTo().tell(
+            new Em1GetConfigOrFailureResponse(
+                  null,
+                  rpcEm1GetConfig(request.id())));
+    } else {
+      request.replyTo().tell(
+            new Em1GetConfigOrFailureResponse(
+                  new NoSuchElementException("unknown EM1 with id " + request.id()),
+                  null));
+    }
+
+    return Behaviors.same();
+  }
+
+  /**
+   * Handle the EM1Data.GetConfig HTTP request
+   * @param request Request to get the EM1 data config
+   * @return Same behavior
+   */
+  protected @NotNull Behavior<Command> onEm1DataGetConfig(@NotNull Em1DataGetConfig request) {
+    logger.trace("ShellyProEM.onEm1DataGetConfig()");
+
+    if (isEm1Channel(request.id())) {
+      request.replyTo().tell(
+            new Em1DataGetConfigOrFailureResponse(null, rpcEm1DataGetConfig(request.id())));
+    } else {
+      request.replyTo().tell(
+            new Em1DataGetConfigOrFailureResponse(
+                  new NoSuchElementException("unknown EM1Data with id " + request.id()),
+                  null));
+    }
+
+    return Behaviors.same();
+  }
+
+  /**
+   * Handle the EM1Data.GetStatus HTTP request
+   * @param request Request to get the EM1 data status
+   * @return Same behavior
+   */
+  protected @NotNull Behavior<Command> onEm1DataGetStatus(@NotNull Em1DataGetStatus request) {
+    logger.trace("ShellyProEM.onEm1DataGetStatus()");
+
+    if (isEm1Channel(request.id())) {
+      try {
+        request.replyTo().tell(
+              new Em1DataGetStatusOrFailureResponse(
+                    null,
+                    rpcEm1DataGetStatus(request.id())));
+      } catch (RuntimeException e) {
+        request.replyTo().tell(
+              new Em1DataGetStatusOrFailureResponse(e, null));
+      } catch (Exception e) {
+        request.replyTo().tell(
+              new Em1DataGetStatusOrFailureResponse(new RuntimeException(e), null));
+      }
+    } else {
+      request.replyTo().tell(
+            new Em1DataGetStatusOrFailureResponse(
+                  new NoSuchElementException("unknown EM1Data with id " + request.id()),
+                  null));
+    }
+
+    return Behaviors.same();
+  }
+
+  @Override
+  protected Rpc.Response createRpcResult(@NotNull InetAddress remoteAddress,
+                                         @NotNull Rpc.Request request) throws RpcException {
+    return switch (request.method().toLowerCase()) {
+      case "em1.getconfig" -> rpcEm1GetConfig(checkEm1Channel(em1RequestId(request)));
+      case "em1.getstatus" -> rpcEm1GetStatus(checkEm1Channel(em1RequestId(request)), getPowerFactorForRemoteAddress(remoteAddress));
+      case "em1data.getconfig" -> rpcEm1DataGetConfig(checkEm1Channel(em1RequestId(request)));
+      case "em1data.getstatus" -> rpcEm1DataGetStatus(checkEm1Channel(em1RequestId(request)));
+      default -> super.createRpcResult(remoteAddress, request);
+    };
+  }
+
+  @Override
+  protected Rpc.GetDeviceInfoResponse rpcGetDeviceInfo(@NotNull InetAddress remoteAddress) {
+    logger.trace("ShellyProEM.rpcGetDeviceInfo()");
+
+    Rpc.GetDeviceInfoResponse response = new Rpc.GetDeviceInfoResponse(
+          null,
+          getHostname(remoteAddress),
+          getMac(remoteAddress),
+          1,
+          "SPEM-002CEBEU50",
+          2,
+          getConfig().getString("fw"),
+          "1.4.4",
+          "ProEM50",
+          false,
+          Rpc.RpcStringOrNull.of(null),
+          null
+    );
+
+    logger.trace("ShellyProEM.rpcGetDeviceInfo(): {}", response);
+
+    return response;
+  }
+
+  @Override
+  protected Rpc.Response rpcShellyGetStatus(@NotNull InetAddress remoteAddress) {
+    logger.trace("ShellyProEM.rpcShellyGetStatus()");
+
+    double factor = getPowerFactorForRemoteAddress(remoteAddress);
+
+    ShellyProEMStatus response = new ShellyProEMStatus(
+          rpcBleGetStatus(),
+          rpcBtHomeGetStatus(),
+          rpcCloudGetStatus(),
+          rpcEm1GetStatus(0, factor),
+          rpcEm1GetStatus(1, factor),
+          rpcEm1DataGetStatus(0),
+          rpcEm1DataGetStatus(1),
+          rpcEthGetStatus(),
+          rpcModbusGetStatus(),
+          rpcMqttGetStatus(),
+          rpcSysGetStatus(remoteAddress),
+          rpcTemperatureGetStatus(),
+          rpcWifiGetStatus(),
+          rpcWsGetStatus()
+    );
+
+    logger.trace("ShellyProEM.rpcShellyGetStatus(): {}", response);
+
+    return response;
+  }
+
+  /**
+   * Handle the EM1.GetStatus RPC request
+   * @param id EM1 channel id (0 or 1)
+   * @param factor Power factor to apply for the requesting client
+   * @return Status of the EM1 component
+   */
+  protected Rpc.Em1GetStatusResponse rpcEm1GetStatus(int id, double factor) throws RpcException {
+    logger.trace("ShellyProEM.rpcEm1GetStatus()");
+
+    if (isSwitchedOff()) {
+      throw new TemporaryNotAvailableException("device is not available until " + getOffUntil());
+    }
+
+    if (id == 1) {
+      // the second channel of the emulated device is unused
+      return new Rpc.Em1GetStatusResponse(
+            1,
+            0.0,
+            getDefaultVoltage(),
+            0.0,
+            0.0,
+            1.0,
+            getDefaultFrequency(),
+            "factory",
+            null,
+            null);
+    }
+
+    PowerData powerPhase0 = getPowerPhase0();
+    PowerData powerPhase1 = getPowerPhase1();
+    PowerData powerPhase2 = getPowerPhase2();
+
+    if (powerPhase0 == null && powerPhase1 == null && powerPhase2 == null) {
+      throw new RpcException(RpcError.ERROR_NO_POWER_DATA, RpcError.ERROR_NO_POWER_DATA_MSG);
+    }
+
+    if (powerPhase0 == null) {
+      powerPhase0 = getPowerPhase0OrDefault();
+    }
+    if (powerPhase1 == null) {
+      powerPhase1 = getPowerPhase1OrDefault();
+    }
+    if (powerPhase2 == null) {
+      powerPhase2 = getPowerPhase2OrDefault();
+    }
+
+    double totalPower = (powerPhase0.power() + powerPhase1.power() + powerPhase2.power()) * factor;
+
+    if (checkUsageConstraint(totalPower)) {
+      throw new RpcException(RpcError.ERROR_USAGE_CONSTRAINT, RpcError.ERROR_USAGE_CONSTRAINT_MSG);
+    }
+
+    double totalApparentPower =
+          (powerPhase0.apparentPower() + powerPhase1.apparentPower() + powerPhase2.apparentPower()) * factor;
+
+    double powerFactor = totalApparentPower != 0.0
+          ? totalPower / totalApparentPower
+          : 1.0;
+
+    return new Rpc.Em1GetStatusResponse(
+          0,
+          (powerPhase0.current() + powerPhase1.current() + powerPhase2.current()) * factor,
+          powerPhase0.voltage(),
+          totalPower,
+          totalApparentPower,
+          powerFactor,
+          powerPhase0.frequency(),
+          "factory",
+          null,
+          null);
+  }
+
+  /**
+   * Handle the EM1.GetConfig RPC request
+   * @param id EM1 channel id (0 or 1)
+   * @return Configuration of the EM1 component
+   */
+  protected Rpc.Em1GetConfigResponse rpcEm1GetConfig(int id) {
+    logger.trace("ShellyProEM.rpcEm1GetConfig()");
+
+    return new Rpc.Em1GetConfigResponse(
+          id,
+          new Rpc.RpcStringOrNull(null),
+          false,
+          "50A"
+    );
+  }
+
+  /**
+   * Handle the EM1Data.GetConfig RPC request
+   * @param id EM1 channel id (0 or 1)
+   * @return Configuration of the EM1Data component
+   */
+  protected Rpc.Em1DataGetConfigResponse rpcEm1DataGetConfig(int id) {
+    logger.trace("ShellyProEM.rpcEm1DataGetConfig()");
+    return new Rpc.Em1DataGetConfigResponse();
+  }
+
+  /**
+   * Handle the EM1Data.GetStatus RPC request
+   * @param id EM1 channel id (0 or 1)
+   * @return Status of the EM1Data component
+   */
+  protected Rpc.Em1DataGetStatusResponse rpcEm1DataGetStatus(int id) throws RpcException {
+    logger.trace("ShellyProEM.rpcEm1DataGetStatus()");
+
+    if (isSwitchedOff()) {
+      throw new TemporaryNotAvailableException("device is not available until " + getOffUntil());
+    }
+
+    if (id == 1) {
+      // the second channel of the emulated device is unused
+      return new Rpc.Em1DataGetStatusResponse(1, 0.0, 0.0, null);
+    }
+
+    PowerData powerPhase0 = getPowerPhase0();
+    PowerData powerPhase1 = getPowerPhase1();
+    PowerData powerPhase2 = getPowerPhase2();
+
+    if (powerPhase0 == null && powerPhase1 == null && powerPhase2 == null) {
+      throw new RpcException(RpcError.ERROR_NO_POWER_DATA, RpcError.ERROR_NO_POWER_DATA_MSG);
+    }
+
+    if (powerPhase0 == null) {
+      powerPhase0 = getPowerPhase0OrDefault();
+    }
+    if (powerPhase1 == null) {
+      powerPhase1 = getPowerPhase1OrDefault();
+    }
+    if (powerPhase2 == null) {
+      powerPhase2 = getPowerPhase2OrDefault();
+    }
+
+    double totalPower = (powerPhase0.power() + powerPhase1.power() + powerPhase2.power());
+
+    if (checkUsageConstraint(totalPower)) {
+      throw new RpcException(RpcError.ERROR_USAGE_CONSTRAINT, RpcError.ERROR_USAGE_CONSTRAINT_MSG);
+    }
+
+    return new Rpc.Em1DataGetStatusResponse(
+          0,
+          getEnergyPhase0().totalConsumption() + getEnergyPhase1().totalConsumption() + getEnergyPhase2().totalConsumption(),
+          getEnergyPhase0().totalProduction() + getEnergyPhase1().totalProduction() + getEnergyPhase2().totalProduction(),
+          null);
+  }
+
+  @Override
+  protected Rpc.NotificationParam createNotifyStatusParam() throws RpcException {
+    return new Rpc.Em1GetStatusNotification(
+          Instant.now().toEpochMilli() / 1000.0,
+          rpcEm1GetStatus(0, 1.0)
+    );
+  }
+
+  @Override
+  protected Rpc.ShellyGetComponentsResponse createComponents(@NotNull InetAddress remoteAddress) {
+    double factor = getPowerFactorForRemoteAddress(remoteAddress);
+
+    return new Rpc.ShellyGetComponentsResponse(
+          List.of(
+                new Rpc.Component("ble", rpcBleGetStatus(), rpcBleGetConfig()),
+                new Rpc.Component("em1:0", rpcEm1GetStatus(0, factor), rpcEm1GetConfig(0)),
+                new Rpc.Component("em1:1", rpcEm1GetStatus(1, factor), rpcEm1GetConfig(1)),
+                new Rpc.Component("em1data:0", rpcEm1DataGetStatus(0), rpcEm1DataGetConfig(0)),
+                new Rpc.Component("em1data:1", rpcEm1DataGetStatus(1), rpcEm1DataGetConfig(1))
+          ),
+          1,
+          0,
+          4
+    );
+  }
+
+  @Override
+  protected Rpc.Response createConfig(@NotNull InetAddress remoteAddress) {
+    return new ShellyProEMConfig(
+          new Rpc.BleGetConfigResponse(
+                false,
+                new Rpc.BleGetConfigResponseRpc(true),
+                new Rpc.BleGetConfigResponseObserver(false)),
+          rpcCloudGetConfig(),
+          rpcEm1GetConfig(0),
+          rpcEm1GetConfig(1),
+          rpcEm1DataGetConfig(0),
+          rpcEm1DataGetConfig(1),
+          rpcSysGetConfig(remoteAddress),
+          rpcTemperatureGetConfig(),
+          rpcWifiGetConfig(),
+          rpcWsGetConfig()
+    );
+  }
+
+  /**
+   * Check whether the specified id is a valid EM1 channel
+   * @param id Channel id to check
+   * @return True if the id is a valid EM1 channel
+   */
+  private static boolean isEm1Channel(int id) {
+    return id == 0 || id == 1;
+  }
+
+  /**
+   * Check that the specified id is a valid EM1 channel
+   * @param id Channel id to check
+   * @return The checked channel id
+   */
+  private static int checkEm1Channel(int id) {
+    if (! isEm1Channel(id)) {
+      throw new IllegalArgumentException("unknown EM1 with id " + id);
+    }
+    return id;
+  }
+
+  /**
+   * Extract the requested EM1 channel id from an RPC request
+   * @param request RPC request to extract the channel id from
+   * @return Requested channel id (0 if not specified)
+   */
+  private static int em1RequestId(@NotNull Rpc.Request request) {
+    if (request instanceof Rpc.Em1GetStatus em1GetStatus && em1GetStatus.params() != null) {
+      return em1GetStatus.params().id();
+    }
+    if (request instanceof Rpc.Em1GetConfig em1GetConfig && em1GetConfig.params() != null) {
+      return em1GetConfig.params().id();
+    }
+    if (request instanceof Rpc.Em1DataGetStatus em1DataGetStatus && em1DataGetStatus.params() != null) {
+      return em1DataGetStatus.params().id();
+    }
+    if (request instanceof Rpc.Em1DataGetConfig em1DataGetConfig && em1DataGetConfig.params() != null) {
+      return em1DataGetConfig.params().id();
+    }
+    return 0;
+  }
+
+  public record Em1GetStatus(
+        @JsonProperty("remoteAddress") InetAddress remoteAddress,
+        @JsonProperty("id") int id,
+        @JsonProperty("replyTo") ActorRef<Em1GetStatusOrFailureResponse> replyTo
+  ) implements Command {}
+
+  public record Em1GetStatusOrFailureResponse(
+        @JsonProperty("failure") Exception failure,
+        @JsonProperty("status") Rpc.Em1GetStatusResponse status
+  ) {}
+
+  public record Em1GetConfig(
+        @JsonProperty("id") int id,
+        @JsonProperty("replyTo") ActorRef<Em1GetConfigOrFailureResponse> replyTo
+  ) implements Command {}
+
+  public record Em1GetConfigOrFailureResponse(
+        @JsonProperty("failure") RuntimeException failure,
+        @JsonProperty("status") Rpc.Em1GetConfigResponse status
+  ) {}
+
+  public record Em1DataGetConfig(
+        @JsonProperty("id") int id,
+        @JsonProperty("replyTo") ActorRef<Em1DataGetConfigOrFailureResponse> replyTo
+  ) implements Command {}
+
+  public record Em1DataGetConfigOrFailureResponse(
+        @JsonProperty("failure") RuntimeException failure,
+        @JsonProperty("status") Rpc.Em1DataGetConfigResponse status
+  ) {}
+
+  public record Em1DataGetStatus(
+        @JsonProperty("remoteAddress") InetAddress remoteAddress,
+        @JsonProperty("id") int id,
+        @JsonProperty("replyTo") ActorRef<Em1DataGetStatusOrFailureResponse> replyTo
+  ) implements Command {}
+
+  public record Em1DataGetStatusOrFailureResponse(
+        @JsonProperty("failure") RuntimeException failure,
+        @JsonProperty("status") Rpc.Em1DataGetStatusResponse status
+  ) {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record ShellyProEMStatus(
+        @JsonProperty("ble") Rpc.BleGetStatusResponse ble,
+        @JsonProperty("bthome") Rpc.BtHomeGetStatusResponse bthome,
+        @JsonProperty("cloud") Rpc.CloudGetStatusResponse cloud,
+        @JsonProperty("em1:0") Rpc.Em1GetStatusResponse em10,
+        @JsonProperty("em1:1") Rpc.Em1GetStatusResponse em11,
+        @JsonProperty("em1data:0") Rpc.Em1DataGetStatusResponse em1data0,
+        @JsonProperty("em1data:1") Rpc.Em1DataGetStatusResponse em1data1,
+        @JsonProperty("eth") Rpc.EthGetStatusResponse eth,
+        @JsonProperty("modbus") Rpc.ModbusGetStatusResponse modbus,
+        @JsonProperty("mqtt") Rpc.MqttGetStatusResponse mqtt,
+        @JsonProperty("sys") Rpc.SysGetStatusResponse sys,
+        @JsonProperty("temperature:0") Rpc.TemperatureGetStatusResponse temperature0,
+        @JsonProperty("wifi") Rpc.WifiGetStatusResponse wifi,
+        @JsonProperty("ws") Rpc.WsGetStatusResponse ws
+  ) implements Rpc.Response {}
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public record ShellyProEMConfig(
+        @JsonProperty("ble") Rpc.BleGetConfigResponse ble,
+        @JsonProperty("cloud") Rpc.CloudGetConfigResponse cloud,
+        @JsonProperty("em1:0") Rpc.Em1GetConfigResponse em10,
+        @JsonProperty("em1:1") Rpc.Em1GetConfigResponse em11,
+        @JsonProperty("em1data:0") Rpc.Em1DataGetConfigResponse em1data0,
+        @JsonProperty("em1data:1") Rpc.Em1DataGetConfigResponse em1data1,
+        @JsonProperty("sys") Rpc.SysGetConfigResponse sys,
+        @JsonProperty("temperature:0") Rpc.TemperatureGetConfigResponse temperature0,
+        @JsonProperty("wifi") Rpc.WifiGetConfigResponse wifi,
+        @JsonProperty("ws") Rpc.WsGetConfigResponse ws
+  ) implements Rpc.Response {}
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -60,6 +60,7 @@ uni-meter {
         type = "SPEM-003CEBEU120"
         mac = ""
         hostname = ""
+        hostname-prefix = "ShellyPro3EM-"
         num_outputs = 0
         num_meters = 3
       }
@@ -102,6 +103,64 @@ uni-meter {
         ver = "1.7.1"
       }
     } 
+
+    shelly-proem {
+      type = "ShellyProEM"
+
+      port = 80
+      interface = "0.0.0.0"
+      udp-port = -1
+      udp-interface = "0.0.0.0"
+      udp-restart-backoff = 15s
+      min-sample-period = 1ms
+
+      device {
+        type = "SPEM-002CEBEU50"
+        mac = ""
+        hostname = ""
+        hostname-prefix = "ShellyProEM50-"
+        num_outputs = 0
+        num_meters = 2
+      }
+      wifi {
+        connected = true
+        ssid = "wifi-ssid"
+        ip = "192.168.178.99"
+        rssi = "-83"
+      }
+      cloud {
+        enabled = false
+        connected = false
+        server = "shelly-143-eu.shelly.cloud:6022/jrpc"
+      }
+      wifi_ap {
+        enabled = false
+        ssid = "shellyproem50-b827eb364242"
+        key = ""
+      }
+      login {
+        enabled = false
+        unprotected = false
+        username = "admin"
+      }
+      ws {
+        enabled = false
+        server = ""
+        ssl_ca = "*"
+      }
+      discoverable = true
+
+      fw = "20250924-062729/1.7.1-gd336f31"
+
+      mdns {
+        gen = "2"
+        app = "ProEM50"
+        model = "SPEM-002CEBEU50"
+        arch = "esp32"
+        fw_id = "20250924-062729/1.7.1-gd336f31"
+        ver = "1.7.1"
+      }
+    }
 
     eco-tracker {
       type = "EcoTracker"


### PR DESCRIPTION
## Summary

Adds a new output device type `ShellyProEM` which emulates the single phase **Shelly Pro EM-50** (`SPEM-002CEBEU50`).

In contrast to the three phase Shelly Pro 3EM, the Pro EM provides two single phase meter channels (`EM1`/`EM1Data` components) instead of the three phase `EM`/`EMData` component. The emulation reports the summed up power and energy data of all input phases on channel `0`, while channel `1` is reported as unused. This helps consumers which only support single phase Shelly devices or which misinterpret the three phase data of the Pro 3EM as described in #382 (Indevolt PowerFlex 2000 Eco treating solar production data of the three phases as consumption).

Closes #382

## Implementation

* New output device `ShellyProEM` (config block `uni-meter.output-devices.shelly-proem`) which extends the existing `ShellyPro3EM` actor and overrides the device identity and the meter components:
  * `Shelly.GetDeviceInfo` reports `model: SPEM-002CEBEU50`, `app: ProEM50`, `gen: 2`, hostname `ShellyProEM50-<MAC>` and no `profile` field, matching a real Pro EM-50
  * `Shelly.GetStatus`, `Shelly.GetConfig` and `Shelly.GetComponents` expose `em1:0`, `em1:1`, `em1data:0` and `em1data:1` instead of `em:0`/`emdata:0`
  * `NotifyStatus` on the outbound websocket connection carries an `em1:0` payload
* New `EM1.GetStatus/GetConfig` and `EM1Data.GetStatus/GetConfig` RPC methods, available via HTTP GET, JSON RPC over HTTP POST, websocket and UDP. The `EM1` HTTP GET routes are only registered for the Pro EM device, the Pro 3EM behaves exactly as before
* The `min-sample-period` throttling of the websocket/UDP status polling now also applies to `EM1.GetStatus` requests
* New `device.hostname-prefix` configuration value (defaults to `ShellyPro3EM-`/`ShellyProEM50-` per device) used to build the default hostname from the mac address
* Documentation (`doc/output/ShellyProEM.md`), README and CHANGELOG updated

## Testing

* `mvn test` passes
* Manual smoke test with a `generic-http` input feeding 423.5 W / mono phase:
  * `GET /rpc/EM1.GetStatus?id=0` → `{"id":0,"current":1.83,"voltage":230.00,"act_power":423.51,"aprt_power":423.51,"pf":1.00,"freq":50.00,"calibration":"factory"}`
  * `EM1.GetStatus`/`EM1Data.GetStatus` verified via HTTP GET, JSON RPC over HTTP POST and JSON RPC over UDP (`udp-port`), including the unused channel `1` and proper error responses for invalid channel ids
  * `Shelly.GetDeviceInfo`, `/shelly`, `/settings`, `Shelly.GetStatus`, `Shelly.GetConfig`, `Shelly.GetComponents` verified to return the Pro EM component layout
* Regression test with the `shelly-pro3em` output: unchanged behavior, `EM1.*` endpoints correctly return 404 there
---

*This change was developed together with Claude (Anthropic's AI coding assistant): implementation, smoke testing and regression testing were done in a Claude Code session. Session: https://claude.ai/code/session_01N3pBKn7wJwAwW8uTWSLJWM*