### PR TITLE
Add support for Refoss EM06P Smart Energy Monitor Input

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ The real electrical meter data can be gathered from the following input devices:
 - Kostal Smart Energy Meter
 - MQTT
 - Powerfox poweropti
+- Refoss EM06P
 - Shelly 3EM
 - Shelly Pro 3EM
 - SHRDZM smartmeter interface module (UDP)
@@ -127,6 +128,7 @@ To configure the input device, follow the instructions in these sections:
 * **[Kostal Smart Energy Meter](doc/input/Kostal.md)**
 * **[MQTT](doc/input/Mqtt.md)**
 * **[Powerfox poweropti](doc/input/Poweropti.md)**
+* **[Refoss EM06P](doc/input/RefossEm06p.md)**
 * **[Shelly 3EM](doc/input/Shelly3Em.md)**
 * **[Shelly Pro 3EM](doc/input/ShellyPro3Em.md)**
 * **[SHRDZM](doc/input/ShrDzm.md)**

--- a/doc/input/RefossEm06p.md
+++ b/doc/input/RefossEm06p.md
@@ -1,0 +1,30 @@
+# Using a Refoss EM06P as the input source
+
+To use a Refoss EM06P as an input source, set up the `uni-meter.conf` file as follows:
+
+```hocon
+uni-meter {
+  output = "uni-meter.output-devices.<output-device>"
+
+  input = "uni-meter.input-devices.refoss-em06p"
+
+  input-devices {
+    refoss-em06p {
+      url = "http://<refoss-em06p-ip>"
+      power-phase-mode = "tri-phase"
+      channel-id-l1 = 1
+      channel-id-l2 = 2
+      channel-id-l3 = 3
+    }
+  }
+}
+```
+
+Replace the `<refoss-em06p-ip>` placeholder with the actual IP of your Refoss EM06P device.
+
+## Phase Modes and Channel Mapping
+
+The Refoss EM06P device supports 6 channels. You can use this input source in two modes depending on your setup:
+
+* **3-Phase Meter (`tri-phase`)**: Set `power-phase-mode = "tri-phase"`. The plugin will read the channels specified by `channel-id-l1`, `channel-id-l2`, and `channel-id-l3`, reporting them as the 3 phases of a 3-phase meter.
+* **1-Phase Meter (`mono-phase`)**: Set `power-phase-mode = "mono-phase"`. The plugin will read only the channel specified by `channel-id`, reporting as a single-phase meter. You can additionally specify `power-phase = "l1"` (or `l2`, `l3`) to define which output phase the data corresponds to.

--- a/src/main/java/com/deigmueller/uni_meter/application/UniMeter.java
+++ b/src/main/java/com/deigmueller/uni_meter/application/UniMeter.java
@@ -1,6 +1,7 @@
 package com.deigmueller.uni_meter.application;
 
 import com.deigmueller.uni_meter.input.InputDevice;
+import com.deigmueller.uni_meter.input.device.refoss.em06p.RefossEm06p;
 import com.deigmueller.uni_meter.input.device.generic_http.GenericHttp;
 import com.deigmueller.uni_meter.input.device.home_assistant.HomeAssistant;
 import com.deigmueller.uni_meter.input.device.modbus.huawei.HuaweiInverter;
@@ -356,6 +357,15 @@ public class UniMeter extends AbstractBehavior<UniMeter.Command> {
               "input");
       }
           
+      case RefossEm06p.TYPE -> {
+        return getContext().spawn(
+              Behaviors.supervise(
+                    RefossEm06p.create(
+                          output,
+                          getContext().getSystem().settings().config().getConfig(inputDeviceConfigPath))
+              ).onFailure(SupervisorStrategy.restartWithBackoff(minBackoff, maxBackoff, jitter)),
+              "input");
+      }
       default -> {
         logger.error("unknown input device type: {}", inputDeviceType);
         throw new IllegalArgumentException("unknown input device type: " + inputDeviceType);

--- a/src/main/java/com/deigmueller/uni_meter/input/device/refoss/em06p/RefossEm06p.java
+++ b/src/main/java/com/deigmueller/uni_meter/input/device/refoss/em06p/RefossEm06p.java
@@ -1,0 +1,193 @@
+package com.deigmueller.uni_meter.input.device.refoss.em06p;
+
+import com.deigmueller.uni_meter.input.device.common.http.HttpInputDevice;
+import com.deigmueller.uni_meter.output.OutputDevice;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.typesafe.config.Config;
+import org.apache.pekko.actor.typed.ActorRef;
+import org.apache.pekko.actor.typed.Behavior;
+import org.apache.pekko.actor.typed.javadsl.ActorContext;
+import org.apache.pekko.actor.typed.javadsl.Behaviors;
+import org.apache.pekko.actor.typed.javadsl.ReceiveBuilder;
+import org.apache.pekko.http.javadsl.model.HttpEntity;
+import org.apache.pekko.http.javadsl.model.HttpRequest;
+import org.apache.pekko.http.javadsl.model.HttpResponse;
+import org.jetbrains.annotations.NotNull;
+
+import java.io.IOException;
+import java.time.Duration;
+
+public class RefossEm06p extends HttpInputDevice {
+    public static final String TYPE = "RefossEm06p";
+
+    private final ObjectMapper objectMapper = Rpc.createObjectMapper();
+    private final String url = getConfig().getString("url");
+    private final Duration pollingInterval = getConfig().getDuration("polling-interval");
+    private final PhaseMode powerPhaseMode = getPhaseMode("power-phase-mode");
+    private final String powerPhase = getConfig().getString("power-phase");
+    private final int channelId = getConfig().getInt("channel-id");
+    private final int channelIdL1 = getConfig().getInt("channel-id-l1");
+    private final int channelIdL2 = getConfig().getInt("channel-id-l2");
+    private final int channelIdL3 = getConfig().getInt("channel-id-l3");
+
+    public static Behavior<Command> create(@NotNull ActorRef<OutputDevice.Command> outputDevice,
+                                           @NotNull Config config) {
+        return Behaviors.setup(context -> new RefossEm06p(context, outputDevice, config));
+    }
+
+    protected RefossEm06p(@NotNull ActorContext<Command> context,
+                          @NotNull ActorRef<OutputDevice.Command> outputDevice,
+                          @NotNull Config config) {
+        super(context, outputDevice, config);
+        executePolling();
+    }
+
+    @Override
+    public ReceiveBuilder<Command> newReceiveBuilder() {
+        return super.newReceiveBuilder()
+                .onMessage(StatusRequestFailed.class, this::onStatusRequestFailed)
+                .onMessage(StatusRequestSuccess.class, this::onStatusRequestSuccess)
+                .onMessage(ExecuteNextPolling.class, this::onExecuteNextPolling);
+    }
+
+    protected Behavior<Command> onStatusRequestFailed(@NotNull StatusRequestFailed message) {
+        logger.trace("RefossEm06p.onStatusRequestFailed()");
+        logger.error("failed to execute status polling: {}", message.throwable().getMessage());
+        startNextPollingTimer();
+        return Behaviors.same();
+    }
+
+    protected Behavior<Command> onStatusRequestSuccess(@NotNull StatusRequestSuccess message) {
+        logger.trace("RefossEm06p.onStatusRequestSuccess()");
+
+        HttpResponse httpResponse = message.response();
+        try {
+            httpResponse.entity()
+                    .toStrict(5000, getMaterializer())
+                    .whenComplete((strictEntity, toStrictFailure) -> {
+                        if (toStrictFailure != null) {
+                            httpResponse.discardEntityBytes(getMaterializer());
+                            getContext().getSelf().tell(new StatusRequestFailed(toStrictFailure));
+                        } else {
+                            if (httpResponse.status().isSuccess()) {
+                                handleStatusEntity(strictEntity);
+                            } else {
+                                getContext().getSelf().tell(new StatusRequestFailed(new IOException(
+                                        "http request failed with status " + httpResponse.status())));
+                            }
+                        }
+                    });
+        } catch (Exception e) {
+            getContext().getSelf().tell(new StatusRequestFailed(e));
+        }
+
+        return Behaviors.same();
+    }
+
+    protected Behavior<Command> onExecuteNextPolling(@NotNull ExecuteNextPolling message) {
+        logger.trace("RefossEm06p.onExecuteNextPolling()");
+        executePolling();
+        return Behaviors.same();
+    }
+
+    private void handleStatusEntity(@NotNull HttpEntity.Strict strictEntity) {
+        logger.trace("RefossEm06p.handleStatusEntity()");
+
+        try {
+            logger.debug("Em.Status.Get response: {}", strictEntity.getData().utf8String());
+
+            Rpc.EmStatusGetResponse response = objectMapper.readValue(strictEntity.getData().toArray(), Rpc.EmStatusGetResponse.class);
+
+            if (response.status() != null) {
+                if (powerPhaseMode == PhaseMode.MONO) {
+                    double power = 0.0;
+                    double apparentPower = 0.0;
+                    double powerFactor = 1.0;
+                    double current = 0.0;
+                    double voltage = getDefaultVoltage();
+                    double frequency = getDefaultFrequency();
+
+                    for (Rpc.EmStatusGetStatus status : response.status()) {
+                         if (status.id() == channelId) {
+                             power = status.power();
+                             current = status.current();
+                             voltage = status.voltage();
+                             powerFactor = status.pf();
+                             break;
+                         }
+                    }
+                    notifyPowerData(powerPhaseMode, powerPhase, power, apparentPower, powerFactor, current, voltage, frequency);
+                } else {
+                    double power1 = 0.0, power2 = 0.0, power3 = 0.0;
+                    double current1 = 0.0, current2 = 0.0, current3 = 0.0;
+                    double voltage1 = getDefaultVoltage(), voltage2 = getDefaultVoltage(), voltage3 = getDefaultVoltage();
+                    double pf1 = 1.0, pf2 = 1.0, pf3 = 1.0;
+
+                    for (Rpc.EmStatusGetStatus status : response.status()) {
+                        if (status.id() == channelIdL1) {
+                            power1 = status.power();
+                            current1 = status.current();
+                            voltage1 = status.voltage();
+                            pf1 = status.pf();
+                        }
+                        if (status.id() == channelIdL2) {
+                            power2 = status.power();
+                            current2 = status.current();
+                            voltage2 = status.voltage();
+                            pf2 = status.pf();
+                        }
+                        if (status.id() == channelIdL3) {
+                            power3 = status.power();
+                            current3 = status.current();
+                            voltage3 = status.voltage();
+                            pf3 = status.pf();
+                        }
+                    }
+
+                    getOutputDevice().tell(
+                            new OutputDevice.NotifyPhasesPowerData(
+                                    getNextMessageId(),
+                                    new OutputDevice.PowerData(power1, 0.0, pf1, current1, voltage1, getDefaultFrequency()),
+                                    new OutputDevice.PowerData(power2, 0.0, pf2, current2, voltage2, getDefaultFrequency()),
+                                    new OutputDevice.PowerData(power3, 0.0, pf3, current3, voltage3, getDefaultFrequency()),
+                                    getOutputDeviceAckAdapter()
+                            )
+                    );
+                }
+            }
+
+        } catch (Exception e) {
+            logger.error("Failed to parse Em.Status.Get response: {}", e.getMessage());
+        }
+
+        startNextPollingTimer();
+    }
+
+    private void executePolling() {
+        logger.trace("RefossEm06p.executePolling()");
+
+        String requestUrl = url + "/rpc/Em.Status.Get?id=" + (powerPhaseMode == PhaseMode.MONO ? channelId : 65535);
+
+        getHttp().singleRequest(HttpRequest.create(requestUrl))
+                .whenComplete((response, throwable) -> {
+                    if (throwable != null) {
+                        getContext().getSelf().tell(new StatusRequestFailed(throwable));
+                    } else {
+                        getContext().getSelf().tell(new StatusRequestSuccess(response));
+                    }
+                });
+    }
+
+    private void startNextPollingTimer() {
+        logger.trace("RefossEm06p.startNextPollingTimer()");
+
+        getContext().getSystem().scheduler().scheduleOnce(
+                pollingInterval,
+                () -> getContext().getSelf().tell(ExecuteNextPolling.INSTANCE),
+                getContext().getExecutionContext());
+    }
+
+    protected record StatusRequestFailed(@NotNull Throwable throwable) implements Command {}
+    protected record StatusRequestSuccess(@NotNull HttpResponse response) implements Command {}
+    protected enum ExecuteNextPolling implements Command { INSTANCE }
+}

--- a/src/main/java/com/deigmueller/uni_meter/input/device/refoss/em06p/Rpc.java
+++ b/src/main/java/com/deigmueller/uni_meter/input/device/refoss/em06p/Rpc.java
@@ -1,0 +1,34 @@
+package com.deigmueller.uni_meter.input.device.refoss.em06p;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+public class Rpc {
+    public static @NotNull ObjectMapper createObjectMapper() {
+        return new ObjectMapper();
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EmStatusGetStatus(
+            @JsonProperty("id") int id,
+            @JsonProperty("current") double current,
+            @JsonProperty("voltage") double voltage,
+            @JsonProperty("power") double power,
+            @JsonProperty("pf") double pf,
+            @JsonProperty("month_energy") double monthEnergy,
+            @JsonProperty("month_ret_energy") double monthRetEnergy,
+            @JsonProperty("week_energy") double weekEnergy,
+            @JsonProperty("week_ret_energy") double weekRetEnergy,
+            @JsonProperty("day_energy") double dayEnergy,
+            @JsonProperty("day_ret_energy") double dayRetEnergy
+    ) {}
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record EmStatusGetResponse(
+            @JsonProperty("status") List<EmStatusGetStatus> status
+    ) {}
+}

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -273,6 +273,20 @@ uni-meter {
       channels = []
     }
 
+
+    refoss-em06p {
+      type = "RefossEm06p"
+      url = "http://127.0.0.1:80"
+      polling-interval = 1s
+      power-phase-mode = "tri-phase"
+      power-phase = "l1"
+      channel-id-l1 = 1
+      channel-id-l2 = 2
+      channel-id-l3 = 3
+      channel-id = 1
+      default-voltage = 230
+      default-frequency = 50
+    }
     tasmota {
       type = "Tasmota"
       url = "http://127.0.0.1:80"


### PR DESCRIPTION
The Code was mainly created with Gemini, but was tested manually, and is working for me.
My Input is the  Refoss EM06P and I use the Ecotracker as Output which is feed in to the Growatt Nexa 2000

 • Implemented RefossEm06p.java to fetch energy data via its JSON-RPC HTTP API (/rpc/Em.Status.Get).
  • Added Rpc.java data models to parse the JSON response from Em.Status.Get.
  • Supported power-phase-mode for both single-phase (mono-phase) and 3-phase (tri-phase) setups.
  • Allowed explicit channel-to-phase mapping via channel-id-l1, channel-id-l2, and channel-id-l3 (for 3-phase) or channel-id and power-phase (for single-phase).
  • Registered the RefossEm06p input device in UniMeter.java.
  • Updated reference.conf with default configuration settings for refoss-em06p.
  • Added documentation in doc/input/RefossEm06p.md and updated README.md.