### PR TITLE
Sample mode on-input-update for the Shelly Pro3EM output

### DIFF
--- a/doc/input/HomeAssistant.md
+++ b/doc/input/HomeAssistant.md
@@ -67,3 +67,30 @@ uni-meter {
   }
 }
 ```
+
+## Notifying the output device only on sensor updates
+
+The Home Assistant sensors are polled in the configured `polling-interval`, which defaults to one second. By default,
+the readings are forwarded to the output device after each polling cycle, even if Home Assistant still provides the
+same sensor values as before.
+
+If the output device is configured to deliver its data on input updates (see the `sample-mode` of the
+[Shelly Pro 3EM](../output/ShellyPro3EM.md) output device), the readings should only be forwarded when the sensors
+really have been updated. To achieve this, set `notify-on-update-only` to `true`. The uni-meter then uses the
+`last_reported` timestamp provided by Home Assistant and forwards the readings only if at least one of the sensors has
+a new timestamp.
+
+```hocon
+uni-meter {
+  #...
+  input-devices {
+    home-assistant {
+      #...
+      polling-interval = 1s
+      notify-on-update-only = true
+      #...
+    }
+  }
+  #...
+}
+```

--- a/doc/output/ShellyPro3EM.md
+++ b/doc/output/ShellyPro3EM.md
@@ -65,6 +65,45 @@ uni-meter {
 }
 ```
 
+## Delivering output data only on input updates
+
+If the input device provides new readings only every few seconds, throttling with a fixed `min-sample-period` does not
+fit well. The throttling period never exactly matches the reading interval of the input device, so the storage sometimes
+gets a reading that is already several seconds old, and sometimes a reading is not delivered at all. If the input device
+delivers its readings at irregular intervals, there is no suitable value at all: a short `min-sample-period` delivers
+the same reading several times while the input device is slow, a long one skips readings while it is fast.
+
+For such setups, you can set the `sample-mode` to `on-input-update` in the `/etc/uni-meter.conf` file. In this mode,
+the requests of the storage are answered as soon as the input device has delivered a new reading, and each reading is
+delivered to the storage only once. If the input device stops delivering readings, the requests are not answered
+anymore and the storage falls back to its default behavior. A configured `min-sample-period` is still respected as the
+minimum time between two answers. Please be aware, that for input devices which poll the physical meter, every poll
+counts as a new reading, so the `polling-interval` of the input device should not be shorter than the update interval
+of the meter.
+
+Some input devices deliver the values of the three phases one after another in separate messages. To avoid that the
+storage gets an answer after each of these messages, the answer is delayed by the `linger-period`, which defaults to
+100 milliseconds. Normally there is no need to change this value, as long as it covers the time between the first and
+the last of these messages.
+
+```hocon
+uni-meter {
+  #...
+  output-devices {
+    shelly-pro3em {
+      #...
+      sample-mode = "on-input-update"
+      linger-period = 100ms
+      #...
+    }
+  }
+  #...
+}
+```
+
+Like the `min-sample-period`, the `sample-mode` only affects the JSON RPC over UDP and the websocket interface. Plain
+HTTP requests to `/rpc/EM.GetStatus` are always answered immediately.
+
 ## Changing the HTTP server port
 
 In its default configuration, the emulated Shelly Pro 3EM listens on port 80 for incoming HTTP requests. That port can 

--- a/doc/output/ShellyPro3EM.md
+++ b/doc/output/ShellyPro3EM.md
@@ -79,7 +79,8 @@ delivered to the storage only once. If the input device stops delivering reading
 anymore and the storage falls back to its default behavior. A configured `min-sample-period` is still respected as the
 minimum time between two answers. Please be aware, that for input devices which poll the physical meter, every poll
 counts as a new reading, so the `polling-interval` of the input device should not be shorter than the update interval
-of the meter.
+of the meter. For the Home Assistant input, set its `notify-on-update-only` option instead (see the
+[Home Assistant input](../input/HomeAssistant.md)), so that only real sensor updates are forwarded.
 
 Some input devices deliver the values of the three phases one after another in separate messages. To avoid that the
 storage gets an answer after each of these messages, the answer is delayed by the `linger-period`, which defaults to

--- a/src/main/java/com/deigmueller/uni_meter/input/device/home_assistant/Entity.java
+++ b/src/main/java/com/deigmueller/uni_meter/input/device/home_assistant/Entity.java
@@ -6,5 +6,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public record Entity(
       @JsonProperty("entity_id") String entityId,
-      @JsonProperty("state") String state
+      @JsonProperty("state") String state,
+      @JsonProperty("last_reported") String lastReported
 ) {}

--- a/src/main/java/com/deigmueller/uni_meter/input/device/home_assistant/HomeAssistant.java
+++ b/src/main/java/com/deigmueller/uni_meter/input/device/home_assistant/HomeAssistant.java
@@ -32,8 +32,11 @@ public class HomeAssistant extends GenericInputDevice {
   private final ObjectMapper objectMapper = new ObjectMapper();
   private final String url = StringUtils.stripEnd(getConfig().getString("url"), "/");
   private final Duration pollingInterval = getConfig().getDuration("polling-interval");
+  private final boolean notifyOnUpdateOnly = getConfig().getBoolean("notify-on-update-only");
   private final Map<String,String> sensorChannelMap = new HashMap<>();
+  private final Map<String,String> sensorLastReportedMap = new HashMap<>();
   private final HttpCredentials credentials;
+  private boolean sensorsUpdated = false;
   
   public static Behavior<Command> create(@NotNull ActorRef<OutputDevice.Command> outputDevice,
                                          @NotNull Config config) {
@@ -95,17 +98,26 @@ public class HomeAssistant extends GenericInputDevice {
         
         String channel = sensorChannelMap.get(message.sensor());
         
-        if (entity.state().equals("unknown")) {
-          setChannelData(channel, 0.0);
-        } else {
-          setChannelData(channel, Double.parseDouble(entity.state()));
+        if (isUpdated(message.sensor(), entity)) {
+          sensorsUpdated = true;
+          
+          if (entity.state().equals("unknown")) {
+            setChannelData(channel, 0.0);
+          } else {
+            setChannelData(channel, Double.parseDouble(entity.state()));
+          }
+          
+          sensorLastReportedMap.put(message.sensor(), entity.lastReported());
         }
       } catch (Exception e) {
         logger.error("failed to parse http response: {} - {}", e.getClass(), e.getMessage());
       }
       
       if (message.remainingSensors().isEmpty()) {
-        notifyOutputDevice();
+        if (sensorsUpdated) {
+          notifyOutputDevice();
+          sensorsUpdated = false;
+        }
         startNextPollingTimer();
       } else {
         readNextSensorValue(message.remainingSensors());
@@ -116,6 +128,20 @@ public class HomeAssistant extends GenericInputDevice {
     }
 
     return Behaviors.same();
+  }
+  
+  /**
+   * Check whether the sensor has been reported to Home Assistant since the last polling cycle
+   * @param sensor Sensor entity id
+   * @param entity Entity read from Home Assistant
+   * @return true if the sensor has been updated or the check is disabled
+   */
+  private boolean isUpdated(@NotNull String sensor, @NotNull Entity entity) {
+    if (!notifyOnUpdateOnly || entity.lastReported() == null) {
+      return true;
+    }
+    
+    return !entity.lastReported().equals(sensorLastReportedMap.get(sensor));
   }
   
   private Behavior<Command> onExecuteNextPollingCycle(@NotNull ExecuteNextPollingCycle message) {

--- a/src/main/java/com/deigmueller/uni_meter/output/device/shelly/Shelly.java
+++ b/src/main/java/com/deigmueller/uni_meter/output/device/shelly/Shelly.java
@@ -20,9 +20,7 @@ import org.apache.pekko.actor.typed.Behavior;
 import org.apache.pekko.actor.typed.javadsl.ActorContext;
 import org.apache.pekko.actor.typed.javadsl.Behaviors;
 import org.apache.pekko.actor.typed.javadsl.ReceiveBuilder;
-import org.apache.pekko.http.javadsl.model.ws.*;
 import org.apache.pekko.http.javadsl.server.Route;
-import org.apache.pekko.stream.connectors.udp.Datagram;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -269,15 +267,13 @@ public abstract class Shelly extends OutputDevice {
         @NotNull UdpServer.Notification notification
   ) implements Command {}
   
-  public record WebsocketProcessPendingEmGetStatusRequest(
-        @NotNull WebsocketContext websocketContext,
-        @NotNull Message websocketMessage
-  ) implements Command {}
+  public enum WebsocketProcessPendingEmGetStatusRequest implements Command {
+    INSTANCE
+  }
 
-  public record UdpClientProcessPendingEmGetStatusRequest(
-        @NotNull UdpClientContext udpClientContext,
-        @NotNull Datagram datagram
-  ) implements Command {}
+  public enum UdpClientProcessPendingEmGetStatusRequest implements Command {
+    INSTANCE
+  }
 
   public enum ThrottlingQueueClosed implements Command {
     INSTANCE
@@ -316,12 +312,17 @@ public abstract class Shelly extends OutputDevice {
   protected static class WebsocketContext {
     private final InetAddress remoteAddress;
     private final ActorRef<WebsocketOutput.Command> output;
-    private Rpc.Request lastEmGetStatusRequest;
+    private WebsocketEmGetStatusRequest lastEmGetStatusRequest;
     
-    public void handleEmGetStatusRequest(@NotNull Rpc.Request emGetStatusRequest) {
-      lastEmGetStatusRequest = emGetStatusRequest;
+    public void handleEmGetStatusRequest(@NotNull Rpc.Request emGetStatusRequest, boolean textMode) {
+      lastEmGetStatusRequest = new WebsocketEmGetStatusRequest(emGetStatusRequest, textMode);
     }
   }
+
+  public record WebsocketEmGetStatusRequest(
+        @NotNull Rpc.Request request,
+        boolean textMode
+  ) {}
 
   @Getter
   @Setter

--- a/src/main/java/com/deigmueller/uni_meter/output/device/shelly/ShellyPro3EM.java
+++ b/src/main/java/com/deigmueller/uni_meter/output/device/shelly/ShellyPro3EM.java
@@ -54,6 +54,8 @@ import java.util.concurrent.CompletionStage;
 public class ShellyPro3EM extends Shelly {
   // Class members
   public static final String TYPE = "ShellyPro3EM";  
+  public static final String SAMPLE_MODE_THROTTLE = "throttle";
+  public static final String SAMPLE_MODE_ON_INPUT_UPDATE = "on-input-update";
   
   // Instance members
   private final ActorRef<WebsocketInput.Notification> websocketInputNotificationAdapter =
@@ -73,6 +75,8 @@ public class ShellyPro3EM extends Shelly {
   private final String udpInterface = getConfig().getString("udp-interface");
   private final Duration udpRestartBackoff = getConfig().getDuration("udp-restart-backoff");
   private Duration minSamplePeriod = getConfig().getDuration("min-sample-period");
+  private final SampleMode sampleMode = getSampleMode("sample-mode");
+  private final Duration lingerPeriod = getConfig().getDuration("linger-period");
 
   private ActorRef<Datagram> udpOutput = null;
   
@@ -81,6 +85,7 @@ public class ShellyPro3EM extends Shelly {
   private InetAddress outboundWebsocketAddress = null;
   private String outboundWebsocketConnectionId = null;
   private boolean outboundWebsocketFailure = false;
+  private boolean lingerPeriodRunning = false;
 
   /**
    * Static setup method
@@ -156,6 +161,7 @@ public class ShellyPro3EM extends Shelly {
           .onMessage(RetryStartUdpServer.class, this::onRetryStartUdpServer)
           .onMessage(UdpClientProcessPendingEmGetStatusRequest.class, this::onUdpClientProcessPendingEmGetStatusRequest)
           
+          .onMessage(LingerPeriodExpired.class, this::onLingerPeriodExpired)
           .onMessage(ThrottlingQueueClosed.class, this::onThrottlingQueueClosed);
   }
 
@@ -692,9 +698,9 @@ public class ShellyPro3EM extends Shelly {
     Rpc.Request request = Rpc.parseRequest(text);
 
     if ("EM.GetStatus".equals(request.method())) {
-      websocketContext.handleEmGetStatusRequest(request);
-      if (websocketThrottlingQueue != null) {
-        websocketThrottlingQueue.offer(new WebsocketProcessPendingEmGetStatusRequest(websocketContext, wsMessage));
+      websocketContext.handleEmGetStatusRequest(request, wsMessage.isText());
+      if (sampleMode == SampleMode.THROTTLE && websocketThrottlingQueue != null) {
+        websocketThrottlingQueue.offer(WebsocketProcessPendingEmGetStatusRequest.INSTANCE);
       }
     } else {
       processRpcRequest(message.remoteAddress(), request, wsMessage.isText(), websocketContext.getOutput());
@@ -865,8 +871,8 @@ public class ShellyPro3EM extends Shelly {
 
     if ("EM.GetStatus".equals(request.method())) {
       udpClientContext.handleEmGetStatusRequest(request);
-      if (udpThrottlingQueue != null) {
-        udpThrottlingQueue.offer(new UdpClientProcessPendingEmGetStatusRequest(udpClientContext, message.datagram()));
+      if (sampleMode == SampleMode.THROTTLE && udpThrottlingQueue != null) {
+        udpThrottlingQueue.offer(UdpClientProcessPendingEmGetStatusRequest.INSTANCE);
       }
     } else {
       processUdpRpcRequest(message.datagram().remote(), request);
@@ -887,6 +893,9 @@ public class ShellyPro3EM extends Shelly {
           processUdpRpcRequest(
                 udpClientContext.getRemote(),
                 udpClientContext.getLastEmGetStatusRequest());
+          if (sampleMode == SampleMode.ON_INPUT_UPDATE) {
+            udpClientContext.setLastEmGetStatusRequest(null);
+          }
         }
       }
     }
@@ -920,12 +929,16 @@ public class ShellyPro3EM extends Shelly {
     
     if (!isSwitchedOff()) {
       for (WebsocketContext websocketContext : websocketConnections.values()) {
-        if (websocketContext.getLastEmGetStatusRequest() != null) {
+        WebsocketEmGetStatusRequest emGetStatusRequest = websocketContext.getLastEmGetStatusRequest();
+        if (emGetStatusRequest != null) {
           processRpcRequest(
                 websocketContext.getRemoteAddress(),
-                websocketContext.getLastEmGetStatusRequest(),
-                message.websocketMessage().isText(),
+                emGetStatusRequest.request(),
+                emGetStatusRequest.textMode(),
                 websocketContext.getOutput());
+          if (sampleMode == SampleMode.ON_INPUT_UPDATE) {
+            websocketContext.setLastEmGetStatusRequest(null);
+          }
         }
       }
     }
@@ -963,6 +976,44 @@ public class ShellyPro3EM extends Shelly {
         }
       }
     }
+
+    if (sampleMode == SampleMode.ON_INPUT_UPDATE) {
+      startLingerPeriod();
+    }
+  }
+
+  /**
+   * Start the linger period if it is not already running
+   */
+  private void startLingerPeriod() {
+    if (!lingerPeriodRunning) {
+      lingerPeriodRunning = true;
+
+      getContext().getSystem().scheduler().scheduleOnce(
+            lingerPeriod,
+            () -> getContext().getSelf().tell(LingerPeriodExpired.INSTANCE),
+            getContext().getExecutionContext());
+    }
+  }
+
+  /**
+   * Handle the notification that the linger period has expired
+   * @param message Notification that the linger period has expired
+   * @return Same behavior
+   */
+  protected Behavior<Command> onLingerPeriodExpired(LingerPeriodExpired message) {
+    logger.trace("ShellyPro3EM.onLingerPeriodExpired()");
+
+    lingerPeriodRunning = false;
+
+    if (websocketThrottlingQueue != null) {
+      websocketThrottlingQueue.offer(WebsocketProcessPendingEmGetStatusRequest.INSTANCE);
+    }
+    if (udpThrottlingQueue != null) {
+      udpThrottlingQueue.offer(UdpClientProcessPendingEmGetStatusRequest.INSTANCE);
+    }
+
+    return Behaviors.same();
   }
 
   /**
@@ -1766,6 +1817,23 @@ public class ShellyPro3EM extends Shelly {
   }
 
   /**
+   * Get the sample mode from the configuration
+   * @param key Name of the configuration parameter
+   * @return Configured sample mode
+   */
+  protected @NotNull SampleMode getSampleMode(@NotNull String key) {
+    String value = getConfig().getString(key);
+
+    if (SAMPLE_MODE_THROTTLE.compareToIgnoreCase(value) == 0) {
+      return SampleMode.THROTTLE;
+    } else if (SAMPLE_MODE_ON_INPUT_UPDATE.compareToIgnoreCase(value) == 0) {
+      return SampleMode.ON_INPUT_UPDATE;
+    } else {
+      throw new IllegalArgumentException("unknown sample mode: " + value);
+    }
+  }
+
+  /**
    * Change the min-sample-period value and restart throttling queues if necessary
    * @param value New min-sample-period value
    */
@@ -1977,5 +2045,14 @@ public class ShellyPro3EM extends Shelly {
   
   public enum RetryStartUdpServer implements Command {
     INSTANCE
+  }
+
+  public enum LingerPeriodExpired implements Command {
+    INSTANCE
+  }
+
+  public enum SampleMode {
+    THROTTLE,
+    ON_INPUT_UPDATE
   }
 }

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -60,6 +60,8 @@ uni-meter {
       udp-interface = "0.0.0.0"
       udp-restart-backoff = 15s
       min-sample-period = 1ms
+      sample-mode = "throttle"
+      linger-period = 100ms
 
       device {
         type = "SPEM-003CEBEU120"

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -336,6 +336,7 @@ uni-meter {
       type = "HomeAssistant"
       url = "http://127.0.0.1"
       polling-interval = 1s
+      notify-on-update-only = false
       access-token = ""
 
       default-voltage = 230


### PR DESCRIPTION
Implements the sample mode discussed in #173 (closes #173), following the two constraints from your comment: no replacement value
when the input stalls, and a linger period instead of waiting for all phases. Four commits: code and documentation
for the output device, then code and documentation for the Home Assistant input, which is needed to make the mode
useful with a polling input.

### Shelly Pro3EM output

Two new options, defaults keep the current behaviour:

```hocon
shelly-pro3em {
  sample-mode = "throttle"      # or "on-input-update"
  linger-period = 100ms
}
```

In `on-input-update` mode an incoming `EM.GetStatus` request (UDP or websocket) is only stored in the client context.
The element for the existing throttling queue is offered when the linger period after a power data notification from
the input device has expired, instead of when the request arrives. Everything downstream is unchanged: the throttle
stage (so `min-sample-period` still acts as a lower limit), the two process handlers, the response building and the
queue lifecycle. A stored request is answered at most once in this mode. If the input stops delivering data, nothing
is answered anymore.

### Home Assistant input

The Home Assistant input forwards its readings after every polling cycle, even if Home Assistant still provides the
same sensor states. With the output in `on-input-update` mode this means one answer to the storage per polling cycle
instead of one per meter reading, which is the case described in the original issue (Tibber Pulse via Home Assistant).

```hocon
home-assistant {
  notify-on-update-only = false   # default keeps the current behaviour
}
```

With `notify-on-update-only = true` the input remembers the `last_reported` timestamp of every sensor (already part of
the `/api/states/<entity>` response, so no additional request) and forwards the readings only if at least one sensor
has a new timestamp. Opt-in, because a sensor that does not change for longer than the `forget-interval` then makes
the output stop delivering data, which is intended in combination with `on-input-update` but would surprise existing
setups.

### Tested

Local setups with a simulated meter / simulated Home Assistant REST API (new reading every ~4.5 s) and a UDP client
polling `EM.GetStatus` every secon:

- GenericHttp input, `on-input-update`: exactly one reply per input reading, ~120 ms after the reading, always to the
  most recent request id, constant 4.5 s between replies, no duplicates. While the meter returned 503 for 12 s, no
  replies were sent; replies resumed with the first new reading.
- default `throttle` with `min-sample-period = 5000ms`: replies every 5.0 s as before.
- Home Assistant input, `notify-on-update-only = true`: 9 state changes, 9 replies; with the default `false`:
  40 polls, 39 replies, i.e. the same value four to five times.
- Real setup (ESPHome SML reader via Home Assistant, Marstek Venus E 3.0, `notify-on-update-only = true`): with
  `min-sample-period = 4600ms` the age of the delivered value at reply time varied between 0.2 s and 3.6 s (median
  2.3 s); with `on-input-update` it was constant at about 0.1 s, one reply per meter reading, no duplicates, reply
  interval following the meter (1 to 9 s, median 4.1 s).
- Websocket path: reviewed only, not tested against a real storage.

Written with Claude Code, as announced in the issue; reviewed and tested by me.